### PR TITLE
Issue openam#36 Remove dependency on ForgeRock Maven repositories

### DIFF
--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -29,7 +29,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>opendj-server-parent</artifactId>
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-config</artifactId>
@@ -41,11 +41,11 @@
   <packaging>bundle</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>i18n-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>i18n-slf4j</artifactId>
     </dependency>
     <dependency>
@@ -53,21 +53,21 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock</groupId>
+      <groupId>jp.openam</groupId>
       <artifactId>forgerock-build-tools</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-cli</artifactId>
     </dependency>
 
@@ -125,7 +125,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <executions>
           <execution>
@@ -147,7 +147,7 @@
       </plugin>
       <!-- Validate core components XML definition files and generate the components. -->
       <plugin>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <artifactId>opendj-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2013-2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -29,7 +30,7 @@
   <parent>
     <artifactId>opendj-server-parent</artifactId>
     <groupId>org.forgerock.opendj</groupId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-config</artifactId>
   <name>OpenDJ Configuration API</name>

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -204,6 +204,7 @@
           </reportSet>
         </reportSets>
       </plugin>
+      <!--
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -213,6 +214,7 @@
           </links>
         </configuration>
       </plugin>
+      -->
     </plugins>
   </reporting>
 </project>

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -29,7 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <artifactId>opendj-server-parent</artifactId>
         <version>3.0.1-SNAPSHOT</version>
     </parent>
@@ -47,102 +47,102 @@
     <dependencies>
         <!-- ForgeRock libraries -->
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-slf4j</artifactId>
         </dependency>
 
         <!-- OpenDJ SDK dependencies -->
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-cli</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <!-- OpenDJ Server dependencies -->
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-config</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <type>jar</type>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>ca_ES</classifier>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>de</classifier>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>es</classifier>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>fr</classifier>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>ja</classifier>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>ko</classifier>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>pl</classifier>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>zh_CN</classifier>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <classifier>zh_TW</classifier>
             <version>${project.version}</version>

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-server-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>opendj-dsml-servlet</artifactId>

--- a/opendj-legacy/pom.xml
+++ b/opendj-legacy/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>opendj-server-parent</artifactId>
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-legacy</artifactId>

--- a/opendj-legacy/pom.xml
+++ b/opendj-legacy/pom.xml
@@ -13,6 +13,7 @@
   ! information: "Portions Copyright [year] [name of copyright owner]".
   !
   ! Copyright 2014-2015 ForgeRock AS.
+  ! Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -20,7 +21,7 @@
   <parent>
     <artifactId>opendj-server-parent</artifactId>
     <groupId>org.forgerock.opendj</groupId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-legacy</artifactId>
   <name>OpenDJ Legacy</name>

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>opendj-server-parent</artifactId>
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <version>3.0.1-SNAPSHOT</version>
   </parent>
 
@@ -46,7 +46,7 @@
 
   <dependencies>
     <dependency>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>forgerock-util</artifactId>
     </dependency>
     <dependency>

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -29,7 +30,7 @@
   <parent>
     <artifactId>opendj-server-parent</artifactId>
     <groupId>org.forgerock.opendj</groupId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>opendj-maven-plugin</artifactId>

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>opendj-server-parent</artifactId>
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <version>3.0.1-SNAPSHOT</version>
   </parent>
 
@@ -40,17 +40,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.http</groupId>
+      <groupId>jp.openam.http</groupId>
       <artifactId>chf-http-servlet</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-rest2ldap</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-grizzly</artifactId>
     </dependency>
   </dependencies>

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -13,6 +13,7 @@
   ! information: "Portions Copyright [year] [name of copyright owner]".
   !
   ! Copyright 2013-2015 ForgeRock AS.
+  ! Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -20,7 +21,7 @@
   <parent>
     <artifactId>opendj-server-parent</artifactId>
     <groupId>org.forgerock.opendj</groupId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>opendj-rest2ldap-servlet</artifactId>

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -29,7 +29,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>opendj-server-parent</artifactId>
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server-example-plugin</artifactId>
@@ -40,15 +40,15 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-config</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>i18n-slf4j</artifactId>
     </dependency>
     <dependency>
@@ -59,7 +59,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <executions>
           <execution>
@@ -77,7 +77,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <artifactId>opendj-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2014-2015 ForgeRock AS
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -29,7 +30,7 @@
   <parent>
     <artifactId>opendj-server-parent</artifactId>
     <groupId>org.forgerock.opendj</groupId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server-example-plugin</artifactId>
   <name>OpenDJ Server Example Plugin</name>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -232,7 +232,7 @@
     <dependency>
       <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-persistit-core</artifactId>
-      <version>4.3.1</version>
+      <version>4.3.2-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -29,7 +29,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <artifactId>opendj-server-parent</artifactId>
     <version>3.0.1-SNAPSHOT</version>
   </parent>
@@ -90,32 +90,32 @@
   <dependencies>
     <!-- ForgeRock libraries -->
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-cli</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-rest2ldap</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>i18n-slf4j</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-config</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-server</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock</groupId>
+      <groupId>jp.openam</groupId>
       <artifactId>forgerock-build-tools</artifactId>
     </dependency>
 
@@ -125,53 +125,53 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-util</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>json-resource</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>json-resource-http</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.http</groupId>
+      <groupId>jp.openam.http</groupId>
       <artifactId>chf-http-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.http</groupId>
+      <groupId>jp.openam.http</groupId>
       <artifactId>chf-http-servlet</artifactId>
     </dependency>
 
     <!-- ForgeRock Common Audit libraries -->
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-audit-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-audit-handler-csv</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-audit-json</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-audit-handler-syslog</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-audit-handler-jdbc</artifactId>
     </dependency>
 
@@ -209,7 +209,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
@@ -230,7 +230,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-persistit-core</artifactId>
       <version>4.3.1</version>
     </dependency>
@@ -370,7 +370,7 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.forgerock.opendj</groupId>
+                  <groupId>jp.openam.opendj</groupId>
                   <artifactId>opendj-maven-plugin</artifactId>
                   <version>${project.version}</version>
                   <type>jar</type>
@@ -394,7 +394,7 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.forgerock.opendj</groupId>
+                  <groupId>jp.openam.opendj</groupId>
                   <artifactId>opendj-legacy</artifactId>
                   <version>${project.version}</version>
                   <type>jar</type>
@@ -409,7 +409,7 @@
 
       <!-- Generate i18n messages -->
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <executions>
           <execution>
@@ -521,7 +521,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <artifactId>opendj-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-server-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server-legacy</artifactId>
   <packaging>jar</packaging>

--- a/opendj-server-legacy/src/main/assembly/opendj-archive-component.xml
+++ b/opendj-server-legacy/src/main/assembly/opendj-archive-component.xml
@@ -35,7 +35,7 @@
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <excludes>
         <exclude>javax.activation:activation</exclude>
-        <exclude>org.forgerock.opendj:opendj-server-legacy</exclude>
+        <exclude>jp.openam.opendj:opendj-server-legacy</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -29,7 +29,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>opendj-server-parent</artifactId>
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server</artifactId>
@@ -49,23 +49,23 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-grizzly</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-config</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>i18n-core</artifactId>
     </dependency>
     <dependency>
@@ -73,17 +73,17 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.forgerock</groupId>
+      <groupId>jp.openam</groupId>
       <artifactId>forgerock-build-tools</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-cli</artifactId>
     </dependency>
   </dependencies>
@@ -141,7 +141,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2013-2015 ForgeRock AS
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -29,7 +30,7 @@
   <parent>
     <artifactId>opendj-server-parent</artifactId>
     <groupId>org.forgerock.opendj</groupId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server</artifactId>
   <name>OpenDJ Server</name>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -180,6 +180,7 @@
           </reportSet>
         </reportSets>
       </plugin>
+      <!--
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -189,6 +190,7 @@
           </links>
         </configuration>
       </plugin>
+      -->
     </plugins>
   </reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,12 +29,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <artifactId>opendj-sdk-parent</artifactId>
         <version>3.0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <artifactId>opendj-server-parent</artifactId>
     <version>3.0.1-SNAPSHOT</version>
 
@@ -63,7 +63,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-              <groupId>org.forgerock.opendj</groupId>
+              <groupId>jp.openam.opendj</groupId>
               <artifactId>opendj-core</artifactId>
               <version>${opendj.core.test.jar.version}</version>
               <type>test-jar</type>
@@ -71,19 +71,19 @@
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>jp.openam.opendj</groupId>
                 <artifactId>opendj-config</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>jp.openam.opendj</groupId>
                 <artifactId>opendj-legacy</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>jp.openam.opendj</groupId>
                 <artifactId>opendj-server</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -111,7 +111,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.forgerock.opendj</groupId>
+                    <groupId>jp.openam.opendj</groupId>
                     <artifactId>opendj-maven-plugin</artifactId>
                     <version>${project.version}</version>
                 </plugin>
@@ -129,7 +129,7 @@
                             <pluginExecutions>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
-                                        <groupId>org.forgerock.opendj</groupId>
+                                        <groupId>jp.openam.opendj</groupId>
                                         <artifactId>opendj-maven-plugin</artifactId>
                                         <versionRange>[1.0.0,)</versionRange>
                                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,12 +31,12 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-sdk-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-server-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -147,7 +148,7 @@
 
     <properties>
         <product.name>OpenDJ</product.name>
-        <opendj.core.test.jar.version>3.0.0</opendj.core.test.jar.version>
+        <opendj.core.test.jar.version>3.0.1-SNAPSHOT</opendj.core.test.jar.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,63 +47,18 @@
         for the identities managed by enterprises.
     </description>
     <inceptionYear>2011</inceptionYear>
-    <url>http://opendj.forgerock.org</url>
+    <url>https://github.com/openam-jp/opendj</url>
 
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/OPENDJ</url>
+        <system>GitHub</system>
+        <url>https://github.com/openam-jp/opendj/issues</url>
     </issueManagement>
 
     <scm>
-        <url>https://stash.forgerock.org/projects/OPENDJ/repos/opendj/browse</url>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj.git</developerConnection>
-      <tag>3.0.0</tag>
-  </scm>
-
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://ci.forgerock.org/view/OpenDJ/job/OpenDJ%20-%20postcommit</url>
-        <notifiers>
-            <notifier>
-                <type>mail</type>
-                <sendOnError>true</sendOnError>
-                <sendOnFailure>true</sendOnFailure>
-                <sendOnSuccess>false</sendOnSuccess>
-                <sendOnWarning>false</sendOnWarning>
-                <address>opendj-dev@forgerock.org</address>
-            </notifier>
-        </notifiers>
-    </ciManagement>
-
-    <repositories>
-        <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>jvnet-nexus-snapshots</id>
-            <url>https://maven.java.net/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
+        <connection>scm:git:https://github.com/openam-jp/opendj.git</connection>
+        <developerConnection>scm:git:git@github.com:openam-jp/opendj.git</developerConnection>
+        <url>https://github.com/openam-jp/opendj</url>
+    </scm>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Analysis
This is OpenDJ project.

In order to fix openam-jp/openam#36, this project also needs modification.

## Solution

* Remove ForgeRock repository tags in pom.xml
* Change Maven groupId
* Adjust maven dependency

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
```
$ mvn install -f forgerock-parent
$ mvn install -f forgerock-bom
$ mvn install -f forgerock-build-tools
$ mvn install -f forgerock-i18n-framework
$ mvn install -f forgerock-guice
$ mvn install -f forgerock-guava
$ mvn install -f forgerock-ui
$ mvn install -DskipTests -f forgerock-commons
$ mvn install -f opendj-sdk
$ mvn install -DskipTests -f forgerock-persistit
$ mvn install -f opendj
```

## Regression testing
N/A