### PR TITLE
Issue openam#81 Unable to change settings due to changelogDb issue of embedded DJ

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/BlockLogReader.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/BlockLogReader.java
@@ -20,8 +20,7 @@
  *
  * CDDL HEADER END
  *
- *
- *      Copyright 2014-2015 ForgeRock AS.
+ * Copyright 2014-2016 ForgeRock AS.
  */
 package org.opends.server.replication.server.changelog.file;
 
@@ -623,7 +622,13 @@ class BlockLogReader<K extends Comparable<K>, V> implements Closeable
 Record<K, V> getNewestRecord() throws ChangelogException
  {
    try {
-     final long lastBlockStart = getClosestBlockStartBeforeOrAtPosition(getFileLength());
+     final long fileLength = getFileLength();
+     long lastBlockStart = getClosestBlockStartBeforeOrAtPosition(fileLength);
+     if (lastBlockStart == fileLength)
+     {
+       // this is not a valid block start, find the previous block start
+       lastBlockStart = getClosestBlockStartBeforeOrAtPosition(fileLength-1);
+     }
      positionToRecordFromBlockStart(lastBlockStart);
      ByteString candidate = readNextRecord();
      ByteString record = candidate;

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/BlockLogReader.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/BlockLogReader.java
@@ -38,6 +38,7 @@ import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.opendj.ldap.ByteStringBuilder;
 import org.forgerock.util.Pair;
 import org.forgerock.util.Reject;
+import org.forgerock.util.annotations.VisibleForTesting;
 import org.opends.server.replication.server.changelog.api.ChangelogException;
 import org.opends.server.replication.server.changelog.api.DBCursor.KeyMatchingStrategy;
 import org.opends.server.replication.server.changelog.api.DBCursor.PositionStrategy;
@@ -539,10 +540,20 @@ class BlockLogReader<K extends Comparable<K>, V> implements Closeable
    *          The position of reader on file.
    * @return the file position of the block start.
    */
+  @VisibleForTesting
   long getClosestBlockStartBeforeOrAtPosition(final long filePosition)
   {
     final int dist = getDistanceToNextBlockStart(filePosition, blockSize);
     return dist == 0 ? filePosition : filePosition + dist - blockSize;
+  }
+
+  @VisibleForTesting
+  long getClosestBlockStartToEndOfFile() throws ChangelogException
+  {
+    final long fileLength = getFileLength();
+    long lastBlockStart = getClosestBlockStartBeforeOrAtPosition(fileLength);
+    // block start is invalid if equal to file length
+    return lastBlockStart < fileLength ? lastBlockStart :  getClosestBlockStartBeforeOrAtPosition(fileLength-1);
   }
 
   /**
@@ -598,8 +609,7 @@ class BlockLogReader<K extends Comparable<K>, V> implements Closeable
  {
    try
    {
-     final long fileSize = getFileLength();
-     final long lastBlockStart = getClosestBlockStartBeforeOrAtPosition(fileSize);
+     final long lastBlockStart = getClosestBlockStartToEndOfFile();
      positionToRecordFromBlockStart(lastBlockStart);
 
      long lastValidPosition = lastBlockStart;
@@ -608,7 +618,7 @@ class BlockLogReader<K extends Comparable<K>, V> implements Closeable
        lastValidPosition = reader.getFilePointer();
      }
 
-     final boolean isFileValid = lastValidPosition == fileSize;
+     final boolean isFileValid = lastValidPosition == getFileLength();
      return isFileValid ? -1 : lastValidPosition;
    }
    catch (Exception e)
@@ -622,13 +632,7 @@ class BlockLogReader<K extends Comparable<K>, V> implements Closeable
 Record<K, V> getNewestRecord() throws ChangelogException
  {
    try {
-     final long fileLength = getFileLength();
-     long lastBlockStart = getClosestBlockStartBeforeOrAtPosition(fileLength);
-     if (lastBlockStart == fileLength)
-     {
-       // this is not a valid block start, find the previous block start
-       lastBlockStart = getClosestBlockStartBeforeOrAtPosition(fileLength-1);
-     }
+     long lastBlockStart = getClosestBlockStartToEndOfFile();
      positionToRecordFromBlockStart(lastBlockStart);
      ByteString candidate = readNextRecord();
      ByteString record = candidate;

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/ReplicationEnvironment.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/ReplicationEnvironment.java
@@ -25,6 +25,9 @@
  */
 package org.opends.server.replication.server.changelog.file;
 
+import static org.opends.messages.ReplicationMessages.*;
+import static org.opends.server.util.StaticUtils.*;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -64,8 +67,6 @@ import org.opends.server.replication.server.changelog.file.Log.LogRotationParame
 import org.opends.server.types.DN;
 import org.opends.server.types.DirectoryException;
 import org.opends.server.util.StaticUtils;
-
-import static org.opends.messages.ReplicationMessages.*;
 
 /**
  * Represents the replication environment, which allows to manage the lifecycle
@@ -384,8 +385,9 @@ class ReplicationEnvironment implements ChangelogStateProvider
     }
     catch (Exception e)
     {
-      throw new ChangelogException(
-          ERR_CHANGELOG_UNABLE_TO_CREATE_REPLICA_DB.get(domainDN.toString(), serverId, generationId), e);
+      LocalizableMessage msg = ERR_CHANGELOG_UNABLE_TO_CREATE_REPLICA_DB.get(
+          domainDN, serverId, generationId, stackTraceToSingleLineString(e));
+      throw new ChangelogException(msg, e);
     }
   }
 

--- a/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
@@ -534,7 +534,7 @@ ERR_CHANGELOG_READ_STATE_CANT_READ_DOMAIN_DIRECTORY_243=Error when retrieving \
  changelog state from root path '%s' : IO error on domain directory '%s' when retrieving \
  list of server ids
 ERR_CHANGELOG_UNABLE_TO_CREATE_REPLICA_DB_244=Could not get or create replica DB \
- for baseDN '%s', serverId '%d', generationId '%d'
+ for baseDN '%s', serverId '%d', generationId '%d': %s
 ERR_CHANGELOG_UNABLE_TO_CREATE_CN_INDEX_DB_245= Could not get or create change \
  number index DB in root path '%s', using path '%s'
 ERR_CHANGELOG_UNABLE_TO_DELETE_GENERATION_ID_FILE_246=Could not retrieve \

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/BlockLogReaderWriterTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/BlockLogReaderWriterTest.java
@@ -273,6 +273,37 @@ public class BlockLogReaderWriterTest extends DirectoryServerTestCase
     assertThat(reader.getClosestBlockStartBeforeOrAtPosition(20)).isEqualTo(20);
   }
 
+  @DataProvider
+  Object[][] recordsForNewest()
+  {
+    return new Object[][]
+    {
+      // raw size taken by each record is: 4 (record size) + 4 (key) + 4 (value) = 12 bytes
+
+      // size of block, records to write
+      { 12, records(1) }, // zero block marker
+      { 10, records(1) }, // one block marker
+      { 8, records(1) },  // one block marker
+      { 7, records(1) },  // two block markers
+      { 6, records(1) },  // three block markers
+      { 5, records(1) },  // seven block markers
+      { 16, records(1,2) }, // one block marker
+      { 12, records(1,2) }, // two block markers
+      { 10, records(1,2) }, // three block markers
+    };
+  }
+
+  @Test(dataProvider="recordsForNewest")
+  public void testGetNewestRecord(int blockSize, List<Record<Integer, Integer>> records) throws Exception
+  {
+    writeRecords(blockSize, records);
+
+    try(BlockLogReader<Integer, Integer> reader = newReader(blockSize))
+    {
+      assertThat(reader.getNewestRecord()).isEqualTo(records.get(records.size()-1));
+    }
+  }
+
   @Test
   public void testGetClosestMarkerStrictlyAfterPosition() throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/BlockLogReaderWriterTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/BlockLogReaderWriterTest.java
@@ -25,7 +25,8 @@
  */
 package org.opends.server.replication.server.changelog.file;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import static org.opends.server.replication.server.changelog.api.DBCursor.KeyMatchingStrategy.*;
 import static org.opends.server.replication.server.changelog.api.DBCursor.PositionStrategy.*;
 import static org.opends.server.replication.server.changelog.file.BlockLogReader.*;
@@ -260,7 +261,7 @@ public class BlockLogReaderWriterTest extends DirectoryServerTestCase
   }
 
   @Test
-  public void testGetClosestMarkerBeforeOrAtPosition() throws Exception
+  public void testGetClosestBlockStartBeforeOrAtPosition() throws Exception
   {
     final int blockSize = 10;
     BlockLogReader<Integer, Integer> reader = newReaderWithNullFile(blockSize);
@@ -301,6 +302,36 @@ public class BlockLogReaderWriterTest extends DirectoryServerTestCase
     try(BlockLogReader<Integer, Integer> reader = newReader(blockSize))
     {
       assertThat(reader.getNewestRecord()).isEqualTo(records.get(records.size()-1));
+    }
+  }
+
+  @DataProvider
+  Object[][] recordsForEndOfFile()
+  {
+    return new Object[][]
+        {
+      // raw size taken by each record is: 4 (record size) + 4 (key) + 4 (value) = 12 bytes
+
+      // size of block, records to write, expected closest block start to end of file
+      { 12, records(1), 0 }, // zero block marker
+      { 10, records(1), 10 }, // one block marker
+      { 8, records(1), 8 },  // one block marker
+      { 7, records(1), 14 },  // two block markers
+      { 6, records(1), 18 },  // three block markers
+      { 5, records(1), 35 },  // seven block markers
+      { 16, records(1,2), 16 }, // one block marker
+      { 12, records(1,2), 24 }, // two block markers
+      { 10, records(1,2), 30 }, // three block markers
+        };
+  }
+  @Test(dataProvider="recordsForEndOfFile")
+  public void testGetClosestBlockStartToEndOfFile(int blockSize, List<Record<Integer, Integer>> records,
+      int expectedBlockStart) throws Exception
+  {
+    writeRecords(blockSize, records);
+    try(BlockLogReader<Integer, Integer> reader = newReader(blockSize))
+    {
+      assertThat(reader.getClosestBlockStartToEndOfFile()).isEqualTo(expectedBlockStart);
     }
   }
 


### PR DESCRIPTION
## Analysis

The OpenDJ replication server requires the changelog database to store update information. The replication server checks whether the change log DB file is valid at startup. In that check, the last record is obtained from the last block of the DB and judged. However, in the current code, if the size of the changelog DB is a multiple of the block size(256 byte), the last block position will be at the end of the file, then EOFException will occur. As a result, the replication server cannot work.

## Solution

cherry-pick OPENDJ-2969 and related fixes(33a4c18, d8a0693, 48b20fb)

## Testing

* Try openam-jp/openam#81 "Steps to reproduce"
* Unit Test (BlockLogReaderWriterTest)
  * `mvn -f opendj-server-legacy -P precommit -Dit.test=BlockLogReaderWriterTest verify`