### PR TITLE
Issue forgerock-bom#2 Promote dependency management by BOM

### DIFF
--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -23,6 +23,7 @@
   !
   !      Copyright 2013-2015 ForgeRock AS.
   !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -75,7 +76,6 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -170,6 +170,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <runOrder>reversealphabetical</runOrder>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -23,6 +23,7 @@
   !
   !      Copyright 2015 ForgeRock AS.
   !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -52,12 +53,10 @@
     <dependency>
         <groupId>org.twdata.maven</groupId>
         <artifactId>mojo-executor</artifactId>
-        <version>2.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>3.2</version>
         <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -23,6 +23,7 @@
   !
   !      Copyright 2011-2015 ForgeRock AS.
   !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -179,13 +180,11 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.1-b02</version>
     </dependency>
 
     <dependency>
       <groupId>org.glassfish.grizzly</groupId>
       <artifactId>grizzly-http-servlet</artifactId>
-      <version>${grizzly-framework.version}</version>
       <exclusions>
         <exclusion>
           <groupId>javax.servlet</groupId>
@@ -197,17 +196,14 @@
     <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>javax.mail</artifactId>
-      <version>1.5.1</version>
     </dependency>
 
     <!-- We need to override testNG version to make test works (see OPENDJ-2389) -->
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.0.1</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>jp.openam.opendj</groupId>
       <artifactId>opendj-core</artifactId>
@@ -218,7 +214,6 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.21</version>
       <scope>test</scope>
     </dependency>
 
@@ -226,7 +221,6 @@
     <dependency>
       <groupId>com.sleepycat</groupId>
       <artifactId>je</artifactId>
-      <version>5.0.104</version>
     </dependency>
 
     <dependency>

--- a/opendj-server-legacy/src/test/java/org/opends/server/admin/ManagedObjectPathTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/admin/ManagedObjectPathTest.java
@@ -23,11 +23,13 @@
  *
  *      Copyright 2008 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.admin;
 
 import static org.opends.server.TestCaseUtils.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 import org.opends.server.DirectoryServerTestCase;
 import org.opends.server.TestCaseUtils;
@@ -298,18 +300,18 @@ public class ManagedObjectPathTest extends DirectoryServerTestCase {
 
     assertEquals(child1, child1);
     assertEquals(child2, child2);
-    assertNotEquals(child1, child2);
-    assertNotEquals(child2, child1);
+    Assert.assertNotEquals(child1, child2);
+    Assert.assertNotEquals(child2, child1);
 
     assertFalse(child1.matches(child3));
     assertFalse(child2.matches(child3));
     assertFalse(child3.matches(child1));
     assertFalse(child3.matches(child2));
 
-    assertNotEquals(child1, child3);
-    assertNotEquals(child2, child3);
-    assertNotEquals(child3, child1);
-    assertNotEquals(child3, child2);
+    Assert.assertNotEquals(child1, child3);
+    Assert.assertNotEquals(child2, child3);
+    Assert.assertNotEquals(child3, child1);
+    Assert.assertNotEquals(child3, child2);
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/api/PasswordValidatorTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/api/PasswordValidatorTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.api;
 
@@ -50,6 +51,7 @@ import org.testng.annotations.Test;
 
 import static org.opends.server.TestCaseUtils.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of generic test cases for password validators.
@@ -183,7 +185,7 @@ public class PasswordValidatorTestCase
 
     int returnCode = LDAPPasswordModify.mainPasswordModify(args, false, null,
                                                            null);
-    assertNotEquals(returnCode, 0);
+    Assert.assertNotEquals(returnCode, 0);
 
     assertEquals(TestPasswordValidator.getLastNewPassword(),
                  ByteString.valueOfUtf8("newPassword"));
@@ -520,7 +522,7 @@ public class PasswordValidatorTestCase
     message = r.readMessage();
     ModifyResponseProtocolOp modifyResponse =
          message.getModifyResponseProtocolOp();
-    assertNotEquals(modifyResponse.getResultCode(), 0);
+    Assert.assertNotEquals(modifyResponse.getResultCode(), 0);
 
     assertEquals(TestPasswordValidator.getLastNewPassword(),
                  ByteString.valueOfUtf8("newPassword"));

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java
@@ -24,6 +24,7 @@
  *      Copyright 2008-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS
  *      Portions Copyright 2013 Manuel Gaupp
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -1793,7 +1794,7 @@ private static final  String ACI_PROXY_CONTROL_LEVEL_1 =
     String userResults =
         ldapCompare(adminParam.getLdapCompareArgs("cn:level3 user"),
             LDAPResultCode.COMPARE_TRUE);
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
   }
 
 
@@ -1838,12 +1839,12 @@ private static final  String ACI_PROXY_CONTROL_LEVEL_1 =
               makeModDN(SALES_DN, "cn=sales dept", "0", MANAGER_NEW_DN);
       modEntries(modrdnLdif, LEVEL_1_USER_DN, "pa$$word", PROXY_USER_DN);
       String userNewResults = ldapSearch(userParamNew.getLdapSearchArgs());
-      assertNotEquals(userNewResults, "");
+      Assert.assertNotEquals(userNewResults, "");
       String modrdnLdif1 =
                 makeModDN(SALES_NEW_DN, "cn=sales dept", "0", MANAGER_DN);
       modEntries(modrdnLdif1, LEVEL_1_USER_DN, "pa$$word", PROXY_USER_DN);
       String userOrigResults = ldapSearch(userParamOrig.getLdapSearchArgs());
-      assertNotEquals(userOrigResults, "");
+      Assert.assertNotEquals(userOrigResults, "");
     }
   }
 
@@ -1878,12 +1879,12 @@ private static final  String ACI_PROXY_CONTROL_LEVEL_1 =
                 makeModDN(SALES_DN, "cn=sales dept", "0", MANAGER_NEW_DN);
         modEntries(modrdnLdif, LEVEL_1_USER_DN, "pa$$word");
         String userNewResults = ldapSearch(userParamNew.getLdapSearchArgs());
-        assertNotEquals(userNewResults, "");
+        Assert.assertNotEquals(userNewResults, "");
         String modrdnLdif1 =
                 makeModDN(SALES_NEW_DN, "cn=sales dept", "0", MANAGER_DN);
         modEntries(modrdnLdif1, LEVEL_1_USER_DN, "pa$$word");
         String userOrigResults = ldapSearch(userParamOrig.getLdapSearchArgs());
-        assertNotEquals(userOrigResults, "");
+        Assert.assertNotEquals(userOrigResults, "");
     }
   }
 
@@ -1938,7 +1939,7 @@ private static final  String ACI_PROXY_CONTROL_LEVEL_1 =
             addEntries(BASIC_LDIF__GROUP_SEARCH_TESTS, DIR_MGR_DN, DIR_MGR_PW);
             modEntries(DNS_ALL_ACI, DIR_MGR_DN, DIR_MGR_PW);
             String userResults = ldapSearch(userParam.getLdapSearchArgs());
-            assertNotEquals(userResults, "");
+            Assert.assertNotEquals(userResults, "");
         }
   }
 
@@ -1963,7 +1964,7 @@ private static final  String ACI_PROXY_CONTROL_LEVEL_1 =
             addEntries(BASIC_LDIF__GROUP_SEARCH_TESTS, DIR_MGR_DN, DIR_MGR_PW);
             modEntries(GROUP1_GROUPDN_MODS, DIR_MGR_DN, DIR_MGR_PW);
             String userResults = ldapSearch(userParam.getLdapSearchArgs());
-            assertNotEquals(userResults, "");
+            Assert.assertNotEquals(userResults, "");
             String adminResults = ldapSearch(adminParam.getLdapSearchArgs());
             Assert.assertEquals(adminResults, "");
         }
@@ -1990,9 +1991,9 @@ private static final  String ACI_PROXY_CONTROL_LEVEL_1 =
         addEntries(BASIC_LDIF__SEARCH_TESTS, DIR_MGR_DN, DIR_MGR_PW);
         modEntries(GLOBAL_MODS, DIR_MGR_DN, DIR_MGR_PW);
         String monitorResults = ldapSearch(monitorParam.getLdapSearchArgs());
-        assertNotEquals(monitorResults, "");
+        Assert.assertNotEquals(monitorResults, "");
         String baseResults = ldapSearch(baseParam.getLdapSearchArgs());
-        assertNotEquals(baseResults, "");
+        Assert.assertNotEquals(baseResults, "");
         deleteAttrFromEntry(ACCESS_HANDLER_DN, ATTR_AUTHZ_GLOBAL_ACI, true);
         monitorResults = ldapSearch(monitorParam.getLdapSearchArgs());
         Assert.assertEquals(monitorResults, "");
@@ -2117,9 +2118,9 @@ private static final  String ACI_PROXY_CONTROL_LEVEL_1 =
             null, null, null);
 
       String monitorResults = ldapSearch(monitorParam.getLdapSearchArgs());
-      assertNotEquals(monitorResults, "");
+      Assert.assertNotEquals(monitorResults, "");
       String baseResults = ldapSearch(baseParam.getLdapSearchArgs());
-      assertNotEquals(baseResults, "");
+      Assert.assertNotEquals(baseResults, "");
       deleteAttrFromEntry(ACCESS_HANDLER_DN, ATTR_AUTHZ_GLOBAL_ACI, true);
       monitorResults = ldapSearch(monitorParam.getLdapSearchArgs());
       Assert.assertEquals(monitorResults, "");

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/GetEffectiveRightsTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/GetEffectiveRightsTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2008-2009 Sun Microsystems, Inc.
  *      Portions Copyright 2013-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -30,6 +31,7 @@ import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.config.ConfigConstants.*;
 import static org.opends.server.util.ServerConstants.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 import java.util.Map;
 
@@ -185,7 +187,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(DIR_MGR_DN, PWD, null, "dn:", null,
                     base, filter, "aclRights");
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     checkEntryLevel(attrMap, rRights);
   }
@@ -205,7 +207,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(superUser, PWD, null, "dn: " + superUser, null,
                     base, filter, "aclRights");
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     checkEntryLevel(attrMap, rRights);
     aciLdif=makeAddLDIF("aci", "ou=People,o=test", addAci);
@@ -213,7 +215,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
     userResults =
             LDAPSearchParams(superUser, PWD, null, "dn: " + superUser, null,
                     base, filter, "aclRights");
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     attrMap=getAttrMap(userResults);
     checkEntryLevel(attrMap, arRights);
     aciLdif=makeAddLDIF("aci", "ou=People,o=test", delAci);
@@ -221,7 +223,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
     userResults =
             LDAPSearchParams(superUser, PWD, null, "dn: " + superUser, null,
                     base, filter, "aclRights");
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     attrMap=getAttrMap(userResults);
     checkEntryLevel(attrMap, adrRights);
     aciLdif=makeAddLDIF("aci", "ou=People,o=test", writeAci);
@@ -229,7 +231,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
     userResults =
             LDAPSearchParams(superUser, PWD, null, "dn: " + superUser, null,
                     base, filter, "aclRights");
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     attrMap=getAttrMap(userResults);
     checkEntryLevel(attrMap, adrwRights);
     aciLdif=makeAddLDIF("aci", "ou=People,o=test", proxyAci);
@@ -237,7 +239,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
     userResults =
             LDAPSearchParams(superUser, PWD, null, "dn: " + superUser, null,
                     base, filter, "aclRights");
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     attrMap=getAttrMap(userResults);
     checkEntryLevel(attrMap, allRights);
   }
@@ -258,7 +260,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
      String userResults =
             LDAPSearchCtrl(superUser, PWD, null, OID_GET_EFFECTIVE_RIGHTS,
                     base, filter, "aclRights");
-     assertNotEquals(userResults, "");
+     Assert.assertNotEquals(userResults, "");
      Map<String, String> attrMap = getAttrMap(userResults);
      checkEntryLevel(attrMap, rRights);
      aciLdif=makeAddLDIF("aci", "ou=People,o=test", addAci);
@@ -266,7 +268,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
      userResults =
             LDAPSearchCtrl(superUser, PWD, null, OID_GET_EFFECTIVE_RIGHTS,
                     base, filter, "aclRights");
-     assertNotEquals(userResults, "");
+     Assert.assertNotEquals(userResults, "");
      attrMap=getAttrMap(userResults);
      checkEntryLevel(attrMap, arRights);
      aciLdif=makeAddLDIF("aci", "ou=People,o=test", delAci);
@@ -274,7 +276,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
      userResults =
             LDAPSearchCtrl(superUser, PWD, null, OID_GET_EFFECTIVE_RIGHTS,
                     base, filter, "aclRights");
-     assertNotEquals(userResults, "");
+     Assert.assertNotEquals(userResults, "");
      attrMap=getAttrMap(userResults);
      checkEntryLevel(attrMap, adrRights);
      aciLdif=makeAddLDIF("aci", "ou=People,o=test", writeAci);
@@ -282,7 +284,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
      userResults =
             LDAPSearchCtrl(superUser, PWD, null, OID_GET_EFFECTIVE_RIGHTS,
                     base, filter, "aclRights");
-     assertNotEquals(userResults, "");
+     Assert.assertNotEquals(userResults, "");
      attrMap=getAttrMap(userResults);
      checkEntryLevel(attrMap, adrwRights);
      aciLdif=makeAddLDIF("aci", "ou=People,o=test", proxyAci);
@@ -290,7 +292,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
      userResults =
              LDAPSearchCtrl(superUser, PWD, null, OID_GET_EFFECTIVE_RIGHTS,
                      base, filter, "aclRights");
-     assertNotEquals(userResults, "");
+     Assert.assertNotEquals(userResults, "");
      attrMap=getAttrMap(userResults);
      checkEntryLevel(attrMap, allRights);
    }
@@ -308,7 +310,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
     String userResults =
            LDAPSearchCtrl(DIR_MGR_DN, PWD, null, OID_GET_EFFECTIVE_RIGHTS,
                    base, filter, "aclRights");
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     checkEntryLevel(attrMap, bypassRights);
   }
@@ -332,7 +334,7 @@ public class GetEffectiveRightsTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(superUser, PWD, null, "dn: " + superUser, null,
                     base, filter, "aclRights mail description");
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     checkAttributeLevel(attrMap, "mail", srwMailAttrRights);
     checkAttributeLevel(attrMap, "description", srDescrptionAttrRights);
@@ -363,7 +365,7 @@ public void testSuAttrLevelParams2() throws Exception {
   String userResults =
           LDAPSearchParams(superUser, PWD, null, "dn: " + superUser, attrList,
                   base, filter, "aclRights mail description");
-  assertNotEquals(userResults, "");
+  Assert.assertNotEquals(userResults, "");
   Map<String, String> attrMap = getAttrMap(userResults);
   checkAttributeLevel(attrMap, "mail", srwMailAttrRights);
   checkAttributeLevel(attrMap, "description", srDescrptionAttrRights);
@@ -392,7 +394,7 @@ public void testSuAttrLevelParams3() throws Exception {
   String userResults =
           LDAPSearchParams(superUser, PWD, null, "dn: " + user1, memberAttrList,
                   base, filter, "aclRights");
-  assertNotEquals(userResults, "");
+  Assert.assertNotEquals(userResults, "");
   Map<String, String> attrMap = getAttrMap(userResults);
   checkAttributeLevel(attrMap, "member", selfWriteAttrRights);
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/TargetAttrTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/TargetAttrTestCase.java
@@ -23,13 +23,14 @@
  *
  *      Copyright 2008-2009 Sun Microsystems, Inc.
  *      Portions Copyright 2012-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.authorization.dseecompat;
 
 import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.config.ConfigConstants.*;
 import static org.testng.Assert.*;
-
+import org.testng.Assert;
 import java.util.Map;
 
 import org.opends.server.core.DirectoryServer;
@@ -173,7 +174,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, attrList);
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     checkAttributeVal(attrMap, "l", "Austin");
     checkAttributeVal(attrMap, "sn", "1");
@@ -181,7 +182,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults1 =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, attrList1);
-    assertNotEquals(userResults1, "");
+    Assert.assertNotEquals(userResults1, "");
     Map<String, String> attrMap1 = getAttrMap(userResults1);
     checkAttributeVal(attrMap1, "sn", "1");
     checkAttributeVal(attrMap1, "uid", "user.1");
@@ -191,7 +192,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults2 =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, attrList);
-    assertNotEquals(userResults2, "");
+    Assert.assertNotEquals(userResults2, "");
     Map<String, String> attrMap2 = getAttrMap(userResults2);
     checkAttributeVal(attrMap2, "l", "Austin");
     checkAttributeVal(attrMap2, "sn", "1");
@@ -212,7 +213,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, opAttrList);
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     //The aci attribute type is operational, it should not be there.
     //The other two should be there.
@@ -227,7 +228,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults1 =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, opAttrList);
-    assertNotEquals(userResults1, "");
+    Assert.assertNotEquals(userResults1, "");
     Map<String, String> attrMap1 = getAttrMap(userResults1);
     //All three attributes should be there.
     assertTrue(attrMap1.containsKey("aci"));
@@ -240,7 +241,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults2 =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, aciFilter, opAttrList);
-    assertNotEquals(userResults2, "");
+    Assert.assertNotEquals(userResults2, "");
     Map<String, String> attrMap2 = getAttrMap(userResults2);
     // Only operational attribute aci should be there, the other two should not.
     assertTrue(attrMap2.containsKey("aci"));
@@ -263,7 +264,7 @@ public class TargetAttrTestCase extends AciTestCase {
     // sanity check that search does not return the forbidden attributes
     String searchResults =
             LDAPSearchParams(user3, PWD, null, null, null, user3, filter, "+ *");
-    assertNotEquals(searchResults, "");
+    Assert.assertNotEquals(searchResults, "");
     Map<String, String> attrMap = getAttrMap(searchResults);
     assertFalse(attrMap.containsKey(user3ForbiddenUserAttr));
     assertFalse(attrMap.containsKey(user3ForbiddenOperationalAttr));
@@ -272,28 +273,28 @@ public class TargetAttrTestCase extends AciTestCase {
     // check we can't pre-read the forbidden user attribute
     String modifyLdif1 = makeAddLDIF(user3WritableAttr, user3, "don't care 1");
     String modifyResults1 = preReadModify(user3, PWD, modifyLdif1, user3ForbiddenUserAttr);
-    assertNotEquals(modifyResults1, "");
+    Assert.assertNotEquals(modifyResults1, "");
     Map<String, String> modifyMap1 = getAttrMap(modifyResults1, true);
     assertFalse(modifyMap1.containsKey(user3ForbiddenUserAttr));
 
     // check we can't pre-read the forbidden operational attribute
     String modifyLdif2 = makeAddLDIF(user3WritableAttr, user3, "don't care 2");
     String modifyResults2 = preReadModify(user3, PWD, modifyLdif2, user3ForbiddenOperationalAttr);
-    assertNotEquals(modifyResults2, "");
+    Assert.assertNotEquals(modifyResults2, "");
     Map<String, String> modifyMap2 = getAttrMap(modifyResults2, true);
     assertFalse(modifyMap2.containsKey(user3ForbiddenOperationalAttr));
 
     // check we can pre-read the allowed user attribute
     String modifyLdif3 = makeAddLDIF(user3WritableAttr, user3, "don't care 3");
     String modifyResults3 = preReadModify(user3, PWD, modifyLdif3, user3AllowedUserAttr);
-    assertNotEquals(modifyResults3, "");
+    Assert.assertNotEquals(modifyResults3, "");
     Map<String, String> modifyMap3 = getAttrMap(modifyResults3, true);
     assertTrue(modifyMap3.containsKey(user3AllowedUserAttr));
 
     // check we can pre-read the allowed operational attribute
     String modifyLdif4 = makeAddLDIF(user3WritableAttr, user3, "don't care 4");
     String modifyResults4 = preReadModify(user3, PWD, modifyLdif4, user3AllowedOperationalAttr);
-    assertNotEquals(modifyResults4, "");
+    Assert.assertNotEquals(modifyResults4, "");
     Map<String, String> modifyMap4 = getAttrMap(modifyResults4, true);
     assertTrue(modifyMap4.containsKey(user3AllowedOperationalAttr));
 
@@ -314,7 +315,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, opAttrList);
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     //All should be returned.
     assertTrue(attrMap.containsKey("aci"));
@@ -338,7 +339,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, opAttrList);
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     //Only aci should be returned.
     assertTrue(attrMap.containsKey("aci"));
@@ -362,7 +363,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, opAttrList);
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     //All should be returned.
     assertTrue(attrMap.containsKey("aci"));
@@ -387,7 +388,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, aciFilter, opAttrList);
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     //All should be returned.
     assertTrue(attrMap.containsKey("aci"));
@@ -400,7 +401,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults1 =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, aciFilter, opAttrList);
-    assertNotEquals(userResults1, "");
+    Assert.assertNotEquals(userResults1, "");
     Map<String, String> attrMap1 = getAttrMap(userResults1);
     //All should be returned.
     assertTrue(attrMap1.containsKey("aci"));
@@ -413,7 +414,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults2 =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, opAttrList);
-    assertNotEquals(userResults2, "");
+    Assert.assertNotEquals(userResults2, "");
     Map<String, String> attrMap2 = getAttrMap(userResults2);
     //Only non-operation should be returned.
     assertFalse(attrMap2.containsKey("aci"));
@@ -434,7 +435,7 @@ public class TargetAttrTestCase extends AciTestCase {
     String userResults =
             LDAPSearchParams(user3, PWD, null, null, null,
                     user1, filter, attrList);
-    assertNotEquals(userResults, "");
+    Assert.assertNotEquals(userResults, "");
     Map<String, String> attrMap = getAttrMap(userResults);
     assertTrue(attrMap.containsKey("l"));
     assertTrue(attrMap.containsKey("sn"));

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/GenericBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/GenericBackendTestCase.java
@@ -23,11 +23,13 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.backends;
 
 import static org.opends.server.TestCaseUtils.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 import java.util.ArrayList;
 
@@ -75,7 +77,7 @@ public class GenericBackendTestCase extends BackendTestCase
   {
     DN[] baseDNs = b.getBaseDNs();
     assertNotNull(baseDNs);
-    assertNotEquals(baseDNs.length, 0);
+    Assert.assertNotEquals(baseDNs.length, 0);
   }
 
   /** Tests the {@link Backend#getSupportedControls} method for the provided backend. */

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/SchemaBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/SchemaBackendTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2013-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.backends;
 
@@ -31,6 +32,7 @@ import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.protocols.internal.Requests.*;
 import static org.opends.server.util.StaticUtils.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -410,7 +412,7 @@ public class SchemaBackendTestCase extends BackendTestCase
          "add: objectClass",
          "objectClass: extensibleObject");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -432,7 +434,7 @@ public class SchemaBackendTestCase extends BackendTestCase
          "add: objectClass",
          "objectClass: extensibleObject");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -450,7 +452,7 @@ public class SchemaBackendTestCase extends BackendTestCase
          "changetype: modify",
          "delete: attributeTypes");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -468,7 +470,7 @@ public class SchemaBackendTestCase extends BackendTestCase
          "changetype: modify",
          "replace: attributeTypes");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -673,7 +675,7 @@ public class SchemaBackendTestCase extends BackendTestCase
          "add: attributeTypes",
          "attributeTypes: invalidsyntax");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -695,7 +697,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.99999 SINGLE-VALUE " +
               "X-ORGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
   }
 
   /**
@@ -717,7 +719,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE " +
               "X-ORGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
   }
 
   /**
@@ -739,7 +741,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE " +
               "X-ORGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
   }
 
   /**
@@ -761,7 +763,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE " +
               "X-ORGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
   }
 
   /**
@@ -783,7 +785,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE " +
               "X-APPROX 'xxxundefinedxxx' X-ORGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
   }
 
   /**
@@ -805,7 +807,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE " +
               "USAGE xxxinvalidxxx X-ORGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
   }
 
   /**
@@ -832,7 +834,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE " +
               "X-ORGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
   }
 
   /**
@@ -859,7 +861,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE " +
               "X-ORGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif, System.err), 0);
   }
 
   /**
@@ -881,7 +883,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN " +
               "'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -903,7 +905,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN " +
               "'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1003,7 +1005,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String attrName = "testremoveattributetypeundefined";
     assertFalse(DirectoryServer.getSchema().hasAttributeType(attrName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1029,7 +1031,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String attrName = "name";
     assertTrue(DirectoryServer.getSchema().hasAttributeType(attrName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertTrue(DirectoryServer.getSchema().hasAttributeType(attrName));
   }
 
@@ -1055,7 +1057,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String attrName = "uid";
     assertTrue(DirectoryServer.getSchema().hasAttributeType(attrName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertTrue(DirectoryServer.getSchema().hasAttributeType(attrName));
   }
 
@@ -1117,7 +1119,7 @@ public class SchemaBackendTestCase extends BackendTestCase
       assertFalse(DirectoryServer.getSchema().hasAttributeType(attrName));
       assertEquals(runModify(argsNotPermissive(), ldif), 0);
 
-      assertNotEquals(runModify(argsNotPermissive(), ldif1), 0);
+      Assert.assertNotEquals(runModify(argsNotPermissive(), ldif1), 0);
       assertTrue(DirectoryServer.getSchema().hasAttributeType(attrName));
     }
     finally
@@ -1168,7 +1170,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String attrName = "testremoveattributetypereferencedbydcr";
     assertFalse(DirectoryServer.getSchema().hasAttributeType(attrName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertTrue(DirectoryServer.getSchema().hasAttributeType(attrName));
   }
 
@@ -1210,7 +1212,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String attrName = "testremoveatrefbymruat";
     assertFalse(DirectoryServer.getSchema().hasAttributeType(attrName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
 
     MatchingRuleUse mru =
          DirectoryServer.getSchema().getMatchingRuleUse(matchingRule);
@@ -1358,7 +1360,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String ocName = "testaddobjectclassmultipleconflicts";
     assertFalse(DirectoryServer.getSchema().hasObjectClass(ocName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasObjectClass(ocName));
   }
 
@@ -1417,7 +1419,7 @@ public class SchemaBackendTestCase extends BackendTestCase
          "add: objectClasses",
          "objectClasses: invalidsyntax");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1438,7 +1440,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "'testAddOCUndefinedSuperior' SUP undefined STRUCTURAL " +
               "MUST cn X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1463,7 +1465,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "SUP testAddOCObsoleteSuperiorSup STRUCTURAL MUST cn " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1491,7 +1493,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "STRUCTURAL MUST testAddOCObsoleteRequiredAttrAT " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1519,7 +1521,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "STRUCTURAL MAY testAddOCObsoleteOptionalAttrAT " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1540,7 +1542,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "'testAddOCUndefinedRequired' SUP top STRUCTURAL " +
               "MUST undefined X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1563,7 +1565,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "MUST ( cn $ xxxundefinedxxx ) " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1584,7 +1586,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "'testAddOCUndefinedOptional' SUP top STRUCTURAL " +
               "MAY undefined X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1607,7 +1609,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "MAY ( cn $ xxxundefinedxxx ) " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1628,7 +1630,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "'testAddAbstractOCWithNonAbstractSuperior' SUP person " +
               "ABSTRACT MAY description X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1649,7 +1651,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "'testAddAuxiliaryOCWithStructuralSuperior' SUP person " +
               "AUXILIARY MAY description X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1670,7 +1672,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "'testAddStructuralOCWithAuxiliarySuperior' SUP posixAccount " +
               "STRUCTURAL MAY description X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -1726,7 +1728,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String ocName = "person";
     assertTrue(DirectoryServer.getSchema().hasObjectClass(ocName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertTrue(DirectoryServer.getSchema().hasObjectClass(ocName));
   }
 
@@ -1775,7 +1777,7 @@ public class SchemaBackendTestCase extends BackendTestCase
       assertFalse(DirectoryServer.getSchema().hasObjectClass(ocName));
       assertEquals(runModify(argsPermissive(), addOCThenNF), 0);
 
-      assertNotEquals(runModify(argsPermissive(), deleteOC), 0);
+      Assert.assertNotEquals(runModify(argsPermissive(), deleteOC), 0);
       assertTrue(DirectoryServer.getSchema().hasObjectClass(ocName));
     }
     finally
@@ -1818,7 +1820,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String ocName = "testremoveobjectclassreferencedbydcr";
     assertFalse(DirectoryServer.getSchema().hasObjectClass(ocName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertTrue(DirectoryServer.getSchema().hasObjectClass(ocName));
   }
 
@@ -1944,7 +1946,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String nameFormName = "testaddnameformwithundefinedreqat";
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
   }
 
@@ -1977,7 +1979,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String nameFormName = "testaddnameformwithmultipleundefinedreqat";
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
   }
 
@@ -2009,7 +2011,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String nameFormName = "testaddnameformwithundefinedoptat";
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
   }
 
@@ -2042,7 +2044,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String nameFormName = "testaddnameformwithmultipleundefinedoptat";
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
   }
 
@@ -2067,7 +2069,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String nameFormName = "testaddnameformwithundefinedoc";
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
   }
 
@@ -2098,7 +2100,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String nameFormName = "testaddnameformwithauxiliaryoc";
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
   }
 
@@ -2129,7 +2131,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String nameFormName = "testaddnameformwithobsoleteoc";
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
   }
 
@@ -2163,7 +2165,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "MUST testAddNFWithObsoleteReqATAT " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2196,7 +2198,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "MUST cn MAY testAddNFWithObsoleteOptATAT " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2364,7 +2366,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     String nameFormName = "testremovenameformreferencedbydsrnf";
     assertFalse(DirectoryServer.getSchema().hasNameForm(nameFormName));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertTrue(DirectoryServer.getSchema().hasNameForm(nameFormName));
   }
 
@@ -2557,7 +2559,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleUndefinedOC' NOT description " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2583,7 +2585,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleAuxiliaryOC' NOT description " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2609,7 +2611,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleObsoleteOC' NOT description " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2643,7 +2645,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleConflictingOC2' NOT description " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2669,7 +2671,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleUndefinedAuxOC' " +
               "AUX xxxundefinedxxx X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2697,7 +2699,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "AUX ( posixAccount $ xxxundefinedxxx ) " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2723,7 +2725,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleAuxOCNotAuxOC' " +
               "AUX person X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2751,7 +2753,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "AUX ( posixAccount $ person ) " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2781,7 +2783,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "AUX testAddDITContentRuleObsoleteAuxOCAuxiliary " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2807,7 +2809,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleUndefinedReqAT' " +
               "MUST xxxundefinedxxx X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2835,7 +2837,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "MUST ( cn $ xxxundefinedxxx ) " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2861,7 +2863,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleUndefinedOptAT' " +
               "MAY xxxundefinedxxx X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2889,7 +2891,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "MAY ( cn $ xxxundefinedxxx ) " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2915,7 +2917,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDITContentRuleUndefinedNotAT' " +
               "NOT xxxundefinedxxx X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2943,7 +2945,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NOT ( description $ xxxundefinedxxx ) " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2970,7 +2972,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDCRProhibitReqStructuralAT' " +
               "NOT cn X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -2997,7 +2999,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddDCRProhibitReqAuxiliaryAT' AUX posixAccount " +
               "NOT uid X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3029,7 +3031,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "MUST testAddDCRObsoleteReqATAT " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3061,7 +3063,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "MAY testAddDCRObsoleteOptATAT " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3093,7 +3095,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NOT testAddDCRObsoleteNotATAT " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3342,7 +3344,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     int ruleID = 999004;
     assertFalse(DirectoryServer.getSchema().hasDITStructureRule(ruleID));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasDITStructureRule(ruleID));
   }
 
@@ -3379,7 +3381,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     int ruleID = 999005;
     assertFalse(DirectoryServer.getSchema().hasDITStructureRule(ruleID));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertFalse(DirectoryServer.getSchema().hasDITStructureRule(ruleID));
   }
 
@@ -3413,7 +3415,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "FORM testAddDITStructureRuleObsoleteNameFormNF " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3457,7 +3459,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "FORM testAddDITStructureRuleObsoleteSuperiorNF2 SUP 999012 " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3558,7 +3560,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     int ruleID = 999007;
     assertFalse(DirectoryServer.getSchema().hasDITStructureRule(ruleID));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
     assertTrue(DirectoryServer.getSchema().hasDITStructureRule(ruleID));
 
     ldif = toLdif(
@@ -3771,7 +3773,7 @@ public class SchemaBackendTestCase extends BackendTestCase
 
     assertFalse(DirectoryServer.getSchema().hasMatchingRuleUse(matchingRule));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
 
     MatchingRuleUse mru =
          DirectoryServer.getSchema().getMatchingRuleUse(matchingRule);
@@ -3797,7 +3799,7 @@ public class SchemaBackendTestCase extends BackendTestCase
               "NAME 'testAddMRUMRUndefined' APPLIES cn " +
               "X-ORIGIN 'SchemaBackendTestCase' )");
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3824,7 +3826,7 @@ public class SchemaBackendTestCase extends BackendTestCase
 
     assertFalse(DirectoryServer.getSchema().hasMatchingRuleUse(matchingRule));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3852,7 +3854,7 @@ public class SchemaBackendTestCase extends BackendTestCase
 
     assertFalse(DirectoryServer.getSchema().hasMatchingRuleUse(matchingRule));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3878,7 +3880,7 @@ public class SchemaBackendTestCase extends BackendTestCase
 
     assertFalse(DirectoryServer.getSchema().hasMatchingRuleUse(matchingRule));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   /**
@@ -3909,7 +3911,7 @@ public class SchemaBackendTestCase extends BackendTestCase
 
     assertFalse(DirectoryServer.getSchema().hasMatchingRuleUse(matchingRule));
 
-    assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
+    Assert.assertNotEquals(runModify(argsNotPermissive(), ldif), 0);
   }
 
   private int runModify(String[] args, String ldifContent)
@@ -4339,7 +4341,7 @@ public class SchemaBackendTestCase extends BackendTestCase
 
     ByteString newMTValue =
          schemaEntry.getAttribute(mtType).get(0).iterator().next();
-    assertNotEquals(oldMTValue, newMTValue);
+    Assert.assertNotEquals(oldMTValue, newMTValue);
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/task/TaskBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/task/TaskBackendTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2008-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.backends.task;
 
@@ -46,6 +47,7 @@ import org.testng.annotations.Test;
 import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.util.ServerConstants.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /** A set of test cases that can be used to test the task backend. */
 public class TaskBackendTestCase
@@ -172,7 +174,7 @@ public class TaskBackendTestCase
     int resultCode = TestCaseUtils.applyModifications(true,
       "dn: " + taskDN,
       "changetype: delete");
-    assertNotEquals(resultCode, 0);
+    Assert.assertNotEquals(resultCode, 0);
     assertTrue(DirectoryServer.entryExists(DN.valueOf(taskDN)));
   }
 
@@ -316,7 +318,7 @@ public class TaskBackendTestCase
       "changetype: modify",
       "replace: description",
       "description: foo");
-    assertNotEquals(resultCode, 0);
+    Assert.assertNotEquals(resultCode, 0);
 
 
     // Perform a modification to cancel the task.
@@ -373,7 +375,7 @@ public class TaskBackendTestCase
       "changetype: modify",
       "add: description",
       "description: foo");
-    assertNotEquals(resultCode, 0);
+    Assert.assertNotEquals(resultCode, 0);
 
 
     // Perform a modification to delete that task.
@@ -496,7 +498,7 @@ public class TaskBackendTestCase
             "changetype: modify",
             "replace: ds-recurring-task-schedule",
             "ds-recurring-task-schedule: * * * * *");
-    assertNotEquals(resultCode, 0);
+    Assert.assertNotEquals(resultCode, 0);
 
     // Delete recurring task.
     resultCode =

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/PasswordPolicyControlTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/PasswordPolicyControlTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2008-2009 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.controls;
 
@@ -49,6 +50,7 @@ import org.testng.annotations.Test;
 import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.util.ServerConstants.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * This class contains test cases that verify the appropriate handling of the
@@ -142,7 +144,7 @@ public class PasswordPolicyControlTestCase
 
       message = r.readMessage();
       AddResponseProtocolOp addResponse = message.getAddResponseProtocolOp();
-      assertNotEquals(addResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(addResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -209,7 +211,7 @@ public class PasswordPolicyControlTestCase
 
       message = r.readMessage();
       AddResponseProtocolOp addResponse = message.getAddResponseProtocolOp();
-      assertNotEquals(addResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(addResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -298,7 +300,7 @@ public class PasswordPolicyControlTestCase
 
       message = r.readMessage();
       AddResponseProtocolOp addResponse = message.getAddResponseProtocolOp();
-      assertNotEquals(addResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(addResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -361,7 +363,7 @@ public class PasswordPolicyControlTestCase
 
         message = r.readMessage();
         BindResponseProtocolOp bindResponse = message.getBindResponseProtocolOp();
-        assertNotEquals(bindResponse.getResultCode(), LDAPResultCode.SUCCESS);
+        Assert.assertNotEquals(bindResponse.getResultCode(), LDAPResultCode.SUCCESS);
       }
 
       bindRequest = new BindRequestProtocolOp(
@@ -376,7 +378,7 @@ public class PasswordPolicyControlTestCase
 
       message = r.readMessage();
       BindResponseProtocolOp bindResponse = message.getBindResponseProtocolOp();
-      assertNotEquals(bindResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(bindResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -450,7 +452,7 @@ public class PasswordPolicyControlTestCase
       message = r.readMessage();
       CompareResponseProtocolOp compareResponse =
            message.getCompareResponseProtocolOp();
-      assertNotEquals(compareResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(compareResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -529,7 +531,7 @@ public class PasswordPolicyControlTestCase
       message = r.readMessage();
       DeleteResponseProtocolOp deleteResponse =
            message.getDeleteResponseProtocolOp();
-      assertNotEquals(deleteResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(deleteResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -883,7 +885,7 @@ public class PasswordPolicyControlTestCase
       message = r.readMessage();
       ModifyResponseProtocolOp modifyResponse =
            message.getModifyResponseProtocolOp();
-      assertNotEquals(modifyResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(modifyResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -961,7 +963,7 @@ public class PasswordPolicyControlTestCase
       message = r.readMessage();
       ModifyResponseProtocolOp modifyResponse =
            message.getModifyResponseProtocolOp();
-      assertNotEquals(modifyResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(modifyResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -1041,7 +1043,7 @@ public class PasswordPolicyControlTestCase
       message = r.readMessage();
       ModifyResponseProtocolOp modifyResponse =
            message.getModifyResponseProtocolOp();
-      assertNotEquals(modifyResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(modifyResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -1121,7 +1123,7 @@ public class PasswordPolicyControlTestCase
       message = r.readMessage();
       ModifyResponseProtocolOp modifyResponse =
            message.getModifyResponseProtocolOp();
-      assertNotEquals(modifyResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(modifyResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -1202,7 +1204,7 @@ public class PasswordPolicyControlTestCase
       message = r.readMessage();
       ModifyDNResponseProtocolOp modifyDNResponse =
            message.getModifyDNResponseProtocolOp();
-      assertNotEquals(modifyDNResponse.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(modifyDNResponse.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);
@@ -1278,7 +1280,7 @@ public class PasswordPolicyControlTestCase
       message = r.readMessage();
       SearchResultDoneProtocolOp searchDone =
            message.getSearchResultDoneProtocolOp();
-      assertNotEquals(searchDone.getResultCode(), LDAPResultCode.SUCCESS);
+      Assert.assertNotEquals(searchDone.getResultCode(), LDAPResultCode.SUCCESS);
 
       controls = message.getControls();
       assertNotNull(controls);

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/PersistentSearchControlTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/PersistentSearchControlTest.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.controls;
 
@@ -33,6 +34,7 @@ import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.protocols.internal.Requests.*;
 import static org.opends.server.util.ServerConstants.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 import java.util.*;
 
@@ -435,7 +437,7 @@ public class PersistentSearchControlTest extends ControlsTestCase
       }
       catch (DirectoryException e)
       {
-        assertNotEquals(type.compareTo(MODIFY_DN), 0,
+        Assert.assertNotEquals(type.compareTo(MODIFY_DN), 0,
             "couldn't decode a control with previousDN not null and type=modDN");
       }
     }
@@ -472,7 +474,7 @@ public class PersistentSearchControlTest extends ControlsTestCase
       }
       catch (DirectoryException e)
       {
-        assertNotEquals(type.compareTo(PersistentSearchChangeType.MODIFY_DN), 0,
+        Assert.assertNotEquals(type.compareTo(PersistentSearchChangeType.MODIFY_DN), 0,
             "couldn't decode a control with previousDN not null and type=modDN");
       }
     }

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/ServerSideSortControlTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/ServerSideSortControlTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2008-2009 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.controls;
 
@@ -53,6 +54,7 @@ import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.protocols.internal.Requests.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * This class contains a number of test cases for the server side sort request
@@ -456,7 +458,7 @@ public class ServerSideSortControlTestCase
     SearchRequest request = newSearchRequest("dc=example,dc=com", SearchScope.WHOLE_SUBTREE, "(objectClass=person)")
         .addControl(new ServerSideSortRequestControl(true, "givenName:undefinedOrderingMatch"));
     InternalSearchOperation internalSearch = getRootConnection().processSearch(request);
-    assertNotEquals(internalSearch.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(internalSearch.getResultCode(), ResultCode.SUCCESS);
   }
 
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/AddOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/AddOperationTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.core;
 
@@ -73,6 +74,7 @@ import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.protocols.ldap.LDAPConstants.*;
 import static org.opends.server.util.CollectionUtils.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of test cases for add operations.
@@ -576,7 +578,7 @@ public class AddOperationTestCase
         new LDAPAttribute("ou", "People"));
 
     AddOperation addOperation = getRootConnection().processAdd("invalid", attrs);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -597,7 +599,7 @@ public class AddOperationTestCase
         new LDAPAttribute("o", "test"));
 
     AddOperation addOperation = getRootConnection().processAdd("o=test", attrs);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -618,7 +620,7 @@ public class AddOperationTestCase
         new LDAPAttribute("o", "undefined"));
 
     AddOperation addOperation = getRootConnection().processAdd("o=undefined", attrs);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -639,7 +641,7 @@ public class AddOperationTestCase
         new LDAPAttribute("ou", "People"));
 
     AddOperation addOperation = getRootConnection().processAdd("ou=People,o=undefined", attrs);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -659,7 +661,7 @@ public class AddOperationTestCase
         new LDAPAttribute("ou", "People"));
 
     AddOperation addOperation = getRootConnection().processAdd("ou=People,o=missing,o=test", attrs);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -715,7 +717,7 @@ public class AddOperationTestCase
         new LDAPAttribute("ou", "People"));
 
     AddOperation addOperation = getRootConnection().processAdd(ByteString.valueOfUtf8("ou=People,o=test"), attrs);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
   /**
@@ -865,7 +867,7 @@ public class AddOperationTestCase
 
     AddOperation addOperation =
          getRootConnection().processAdd(ByteString.empty(), attrs);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
   /**
@@ -912,7 +914,7 @@ public class AddOperationTestCase
          "objectClass: organizationalUnit");
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
 
     DirectoryServer.setAddMissingRDNAttributes(true);
   }
@@ -980,7 +982,7 @@ public class AddOperationTestCase
          "ou: People");
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -1002,7 +1004,7 @@ public class AddOperationTestCase
          "ou: People");
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -1025,7 +1027,7 @@ public class AddOperationTestCase
          "ou: People");
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -1051,7 +1053,7 @@ public class AddOperationTestCase
          "sn: User");
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -1078,7 +1080,7 @@ public class AddOperationTestCase
          "userPassword: password"); // Missing cn
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -1107,7 +1109,7 @@ public class AddOperationTestCase
          "userPassword: password"); // Missing cn
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -1137,7 +1139,7 @@ public class AddOperationTestCase
          "dc: Not allowed by inetOrgPerson");
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -1197,7 +1199,7 @@ public class AddOperationTestCase
     userAttrs.put(attrType, newArrayList(Attributes.empty(attrType)));
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -1228,7 +1230,7 @@ public class AddOperationTestCase
     DirectoryServer.setWritabilityMode(WritabilityMode.DISABLED);
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
 
     DirectoryServer.setWritabilityMode(WritabilityMode.ENABLED);
   }
@@ -1354,7 +1356,7 @@ public class AddOperationTestCase
     b.setWritabilityMode(WritabilityMode.DISABLED);
 
     AddOperation addOperation = getRootConnection().processAdd(entry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
 
     b.setWritabilityMode(WritabilityMode.ENABLED);
   }
@@ -1495,7 +1497,7 @@ public class AddOperationTestCase
           "ou: People");
 
       AddOperation addOperation = getRootConnection().processAdd(entry);
-      assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+      Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
 
       assertEquals(changeListener.getAddCount(), 0);
     }finally {

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/BackendConfigManagerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/BackendConfigManagerTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.core;
 
@@ -50,6 +51,7 @@ import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.protocols.internal.Requests.*;
 import static org.opends.server.util.CollectionUtils.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of generic test cases that cover adding, modifying, and removing
@@ -85,7 +87,7 @@ public class BackendConfigManagerTestCase
     Entry backendEntry = createBackendEntry(backendID, false, baseDN);
 
     AddOperation addOperation = getRootConnection().processAdd(backendEntry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -120,7 +122,7 @@ public class BackendConfigManagerTestCase
     Entry backendEntry = createBackendEntry(backendID, false, baseDN);
 
     AddOperation addOperation = getRootConnection().processAdd(backendEntry);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -273,7 +275,7 @@ public class BackendConfigManagerTestCase
 
     // Make sure that we can't remove the parent backend with the child still in place.
     DeleteOperation deleteOperation = conn.processDelete(parentBackendEntry.getName());
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
     assertNotNull(DirectoryServer.getBackend(parentBackendID));
 
     // Delete the child and then delete the parent.

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/DeleteOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/DeleteOperationTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.core;
 
@@ -54,6 +55,7 @@ import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.protocols.ldap.LDAPConstants.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of test cases for delete operations.
@@ -240,7 +242,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     TestCaseUtils.initializeTestBackend(true);
 
     DeleteOperation deleteOperation = processDeleteRaw("ou=People,o=test");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
     @SuppressWarnings("unchecked")
     List<LocalBackendDeleteOperation> localOps =
         (List<LocalBackendDeleteOperation>) deleteOperation.getAttachment(Operation.LOCALBACKENDOPERATIONS);
@@ -356,7 +358,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     TestCaseUtils.initializeTestBackend(true);
 
     DeleteOperation deleteOperation = processDeleteRaw("malformed");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -373,7 +375,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     TestCaseUtils.initializeTestBackend(true);
 
     DeleteOperation deleteOperation = processDeleteRaw("o=does not exist");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -390,7 +392,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     TestCaseUtils.initializeTestBackend(true);
 
     DeleteOperation deleteOperation = processDelete("o=does not exist");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -406,7 +408,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     TestCaseUtils.initializeTestBackend(true);
 
     DeleteOperation deleteOperation = processDeleteRaw("cn=entry,o=does not exist");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -423,7 +425,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     TestCaseUtils.initializeTestBackend(true);
 
     DeleteOperation deleteOperation = processDelete("cn=entry,o=does not exist");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -440,7 +442,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     TestCaseUtils.initializeTestBackend(true);
 
     DeleteOperation deleteOperation = processDeleteRaw("cn=entry,o=test");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -457,7 +459,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     TestCaseUtils.initializeTestBackend(true);
 
     DeleteOperation deleteOperation = processDelete("cn=entry,o=test");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -477,7 +479,7 @@ public class DeleteOperationTestCase extends OperationTestCase
                "cn: test");
 
     DeleteOperation deleteOperation = processDeleteRaw("o=test");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -497,7 +499,7 @@ public class DeleteOperationTestCase extends OperationTestCase
                "cn: test");
 
     DeleteOperation deleteOperation = processDeleteRaw("o=test");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -516,7 +518,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     DirectoryServer.setWritabilityMode(WritabilityMode.DISABLED);
 
     DeleteOperation deleteOperation = processDeleteRaw("o=test");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
 
     DirectoryServer.setWritabilityMode(WritabilityMode.ENABLED);
   }
@@ -580,7 +582,7 @@ public class DeleteOperationTestCase extends OperationTestCase
     backend.setWritabilityMode(WritabilityMode.DISABLED);
 
     DeleteOperation deleteOperation = processDeleteRaw("o=test");
-    assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
 
     backend.setWritabilityMode(WritabilityMode.ENABLED);
   }
@@ -973,7 +975,7 @@ responseLoop:
       assertEquals(changeListener.getAddCount(), 0);
 
       DeleteOperation deleteOperation = processDeleteRaw("cn=nonexistent,o=test");
-      assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
+      Assert.assertNotEquals(deleteOperation.getResultCode(), ResultCode.SUCCESS);
 
       assertEquals(changeListener.getDeleteCount(), 0);
     }

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/ModifyOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/ModifyOperationTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2011 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.core;
 
@@ -83,6 +84,7 @@ import static org.opends.server.protocols.internal.Requests.*;
 import static org.opends.server.protocols.ldap.LDAPConstants.*;
 import static org.opends.server.util.CollectionUtils.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of test cases for modify operations.
@@ -468,7 +470,7 @@ public class ModifyOperationTestCase
   {
     LDAPAttribute attr = newLDAPAttribute("description", "foo");
     ModifyOperation modifyOperation = processModify("invaliddn", replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -483,7 +485,7 @@ public class ModifyOperationTestCase
   {
     LDAPAttribute attr = newLDAPAttribute("description", "foo");
     ModifyOperation modifyOperation = processModify("o=nonexistent", replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -501,7 +503,7 @@ public class ModifyOperationTestCase
   {
     LDAPAttribute attr = newLDAPAttribute("description", "foo");
     ModifyOperation modifyOperation = processModify("cn=test,ou=nosuchparent," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -519,7 +521,7 @@ public class ModifyOperationTestCase
   {
     LDAPAttribute attr = newLDAPAttribute("description", "foo");
     ModifyOperation modifyOperation = processModify("cn=nosuchentry," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -536,7 +538,7 @@ public class ModifyOperationTestCase
          throws Exception
   {
     ModifyOperation modifyOperation = processModify(baseDN);
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -655,7 +657,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("displayName", "foo");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, add(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -687,7 +689,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("ds-pwp-account-disabled", "false");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, add(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -718,7 +720,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("displayName", "foo", "bar");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -750,7 +752,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("ds-pwp-account-disabled", "true", "false");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -819,7 +821,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("givenName", "Test");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, add(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -850,7 +852,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("description", "Foo", "Foo");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -882,7 +884,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("manager", "invaliddn");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -913,7 +915,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("manager", "invaliddn");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, add(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1009,7 +1011,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("uid", "foo");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1040,7 +1042,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = new LDAPAttribute("uid");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1071,7 +1073,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("uid", "test.user");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1102,7 +1104,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("givenName", "Foo");
     ModifyOperation modifyOperation = processModify("givenName=Test,sn=User," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1133,7 +1135,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = new LDAPAttribute("givenName");
     ModifyOperation modifyOperation = processModify("givenName=Test,sn=User," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1293,7 +1295,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = new LDAPAttribute("sn");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1324,7 +1326,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("sn", "User");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1697,7 +1699,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = new LDAPAttribute("displayName");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1728,7 +1730,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("displayName", "Foo");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1759,7 +1761,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = new LDAPAttribute("objectClass");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1790,7 +1792,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = new LDAPAttribute("objectClass");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, replace(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1815,7 +1817,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("objectClass", "organizationalUnit");
     ModifyOperation modifyOperation = processModify("ou=People," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -1840,7 +1842,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("objectClass", "organization");
     ModifyOperation modifyOperation = processModify("ou=People," + baseDN, add(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -2002,7 +2004,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("displayName", "1");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, increment(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -2034,7 +2036,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("description", "notnumeric");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, increment(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -2099,7 +2101,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = new LDAPAttribute("roomNumber");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, increment(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -2131,7 +2133,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("roomNumber", "1", "2");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, increment(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -2162,7 +2164,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("employeeNumber", "1");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, increment(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -2273,7 +2275,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("objectClass", "inetOrgPerson");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, add(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -2305,7 +2307,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("objectClass", "organizationalUnit");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, delete(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
   }
 
@@ -2402,7 +2404,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("objectClass", "extensibleObject");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, add(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
 
     DirectoryServer.setWritabilityMode(WritabilityMode.ENABLED);
@@ -2545,7 +2547,7 @@ public class ModifyOperationTestCase
 
     LDAPAttribute attr = newLDAPAttribute("objectClass", "extensibleObject");
     ModifyOperation modifyOperation = processModify("uid=test.user," + baseDN, add(attr));
-    assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
     retrieveFailedOperationElements(modifyOperation);
 
     b.setWritabilityMode(WritabilityMode.ENABLED);
@@ -2710,7 +2712,7 @@ public class ModifyOperationTestCase
 
       LDAPAttribute attr = newLDAPAttribute("dc", "foo");
       ModifyOperation modifyOperation = processModify(baseDN, replace(attr));
-      assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
+      Assert.assertNotEquals(modifyOperation.getResultCode(), ResultCode.SUCCESS);
       retrieveFailedOperationElements(modifyOperation);
 
       assertEquals(changeListener.getModifyCount(), 0);

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/SubentryPasswordPolicyTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/SubentryPasswordPolicyTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.core;
 
@@ -46,6 +47,7 @@ import org.testng.annotations.Test;
 import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of test cases for the Directory Server subentry password policy.
@@ -239,7 +241,7 @@ public class SubentryPasswordPolicyTestCase
          throws Exception
   {
     AddOperation addOperation = getRootConnection().processAdd(e);
-    assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(addOperation.getResultCode(), ResultCode.SUCCESS);
     assertNull(DirectoryServer.getEntry(e.getName()));
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/crypto/GetSymmetricKeyExtendedOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/crypto/GetSymmetricKeyExtendedOperationTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2008 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.crypto;
 
@@ -48,6 +49,7 @@ import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.config.ConfigConstants.*;
 import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of test cases for the symmetric key extended operation.
@@ -145,6 +147,6 @@ public class GetSymmetricKeyExtendedOperationTestCase
          internalConnection.processExtendedOperation(
               ServerConstants.OID_GET_SYMMETRIC_KEY_EXTENDED_OP, requestValue);
 
-    assertNotEquals(extendedOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(extendedOperation.getResultCode(), ResultCode.SUCCESS);
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/CRAMMD5SASLMechanismHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/CRAMMD5SASLMechanismHandlerTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.v
  */
 package org.opends.server.extensions;
 
@@ -47,6 +48,7 @@ import org.testng.annotations.Test;
 import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.util.ServerConstants.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of test cases for the CRAM-MD5 SASL mechanism handler.
@@ -618,7 +620,7 @@ public class CRAMMD5SASLMechanismHandlerTestCase
     BindOperation bindOperation =
          conn.processSASLBind(DN.rootDN(), SASL_MECHANISM_CRAM_MD5,
                               ByteString.valueOfUtf8("invalid"));
-    assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -643,7 +645,7 @@ public class CRAMMD5SASLMechanismHandlerTestCase
     bindOperation =
          conn.processSASLBind(DN.rootDN(), SASL_MECHANISM_CRAM_MD5,
                               ByteString.valueOfUtf8("malformed"));
-    assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -669,7 +671,7 @@ public class CRAMMD5SASLMechanismHandlerTestCase
          ByteString.valueOfUtf8("dn:cn=Directory Manager malformeddigest");
     bindOperation =
          conn.processSASLBind(DN.rootDN(), SASL_MECHANISM_CRAM_MD5, creds);
-    assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -697,6 +699,6 @@ public class CRAMMD5SASLMechanismHandlerTestCase
                           "malformedcredswiththerightlength");
     bindOperation =
          conn.processSASLBind(DN.rootDN(), SASL_MECHANISM_CRAM_MD5, creds);
-    assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/CRAMMD5SASLMechanismHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/CRAMMD5SASLMechanismHandlerTestCase.java
@@ -23,7 +23,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
- *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.v
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.extensions;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/DigestMD5SASLMechanismHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/DigestMD5SASLMechanismHandlerTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.extensions;
 
@@ -53,6 +54,7 @@ import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.util.ServerConstants.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * A set of test cases for the DIGEST-MD5 SASL mechanism handler.
@@ -931,7 +933,7 @@ public class DigestMD5SASLMechanismHandlerTestCase
     BindOperation bindOperation =
          conn.processSASLBind(DN.rootDN(), SASL_MECHANISM_DIGEST_MD5,
                               ByteString.valueOfUtf8("invalid"));
-    assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
   }
 
 
@@ -955,6 +957,6 @@ public class DigestMD5SASLMechanismHandlerTestCase
     bindOperation =
          conn.processSASLBind(DN.rootDN(), SASL_MECHANISM_DIGEST_MD5,
                               ByteString.valueOfUtf8("malformed"));
-    assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
+    Assert.assertNotEquals(bindOperation.getResultCode(), ResultCode.SUCCESS);
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.replication;
 
@@ -62,6 +63,7 @@ import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.replication.plugin.LDAPReplicationDomain.*;
 import static org.opends.server.util.CollectionUtils.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * Test synchronization of update operations on the directory server and through
@@ -1045,7 +1047,7 @@ public class UpdateOperationTest extends ReplicationTestCase
       @Override
       public Void call() throws Exception
       {
-        assertNotEquals(getMonitorDelta() , 0);
+        Assert.assertNotEquals(getMonitorDelta() , 0);
         return null;
       }
     });
@@ -1323,7 +1325,7 @@ public class UpdateOperationTest extends ReplicationTestCase
           @Override
           public Void call() throws Exception
           {
-            assertNotEquals(getMonitorAttrValue(baseDN, "replayed-updates"), initialCount);
+            Assert.assertNotEquals(getMonitorAttrValue(baseDN, "replayed-updates"), initialCount);
             return null;
           }
         });

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/PrivilegeTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/PrivilegeTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2007-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.types;
 
@@ -86,6 +87,7 @@ import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.protocols.internal.InternalClientConnection.*;
 import static org.opends.server.protocols.internal.Requests.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 /**
  * This class provides a set of test cases for the Directory Server privilege
@@ -1664,7 +1666,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(args), 0);
+    Assert.assertNotEquals(runSearch(args), 0);
   }
 
 
@@ -1726,7 +1728,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(args), 0);
+    Assert.assertNotEquals(runSearch(args), 0);
   }
 
 
@@ -1757,7 +1759,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(args), 0);
+    Assert.assertNotEquals(runSearch(args), 0);
   }
 
 
@@ -1819,7 +1821,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(args), 0);
+    Assert.assertNotEquals(runSearch(args), 0);
   }
 
 
@@ -2036,7 +2038,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(args), 0);
+    Assert.assertNotEquals(runSearch(args), 0);
   }
 
 
@@ -2098,7 +2100,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(args), 0);
+    Assert.assertNotEquals(runSearch(args), 0);
   }
 
 
@@ -2129,7 +2131,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(args), 0);
+    Assert.assertNotEquals(runSearch(args), 0);
   }
 
 
@@ -2191,7 +2193,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(args), 0);
+    Assert.assertNotEquals(runSearch(args), 0);
   }
 
 
@@ -2222,7 +2224,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "(objectClass=*)"
     };
 
-    assertNotEquals(runSearch(searchArgs), 0);
+    Assert.assertNotEquals(runSearch(searchArgs), 0);
 
 
     // Disable the PROXIED_AUTH privilege and verify that the operation now
@@ -2239,7 +2241,7 @@ public class PrivilegeTestCase extends TypesTestCase
       "set-global-configuration-prop",
       "--remove", "disabled-privilege:proxied-auth");
 
-    assertNotEquals(runSearch(searchArgs), 0);
+    Assert.assertNotEquals(runSearch(searchArgs), 0);
   }
 
   private int runSearch(String[] args)

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/TestDN.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/TestDN.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2009 Sun Microsystems, Inc.
  *      Portions Copyright 2012-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.types;
 
@@ -1155,7 +1156,7 @@ public class TestDN extends TypesTestCase {
     if (result == 0) {
       assertEquals   (dn1, dn2, "DN equality for <" + first + "> and <" + second + ">");
     } else {
-      assertNotEquals(dn1, dn2, "DN equality for <" + first + "> and <" + second + ">");
+      Assert.assertNotEquals(dn1, dn2, "DN equality for <" + first + "> and <" + second + ">");
     }
   }
 
@@ -1171,7 +1172,7 @@ public class TestDN extends TypesTestCase {
   public void testEqualsNonDN() throws Exception {
     DN dn = DN.valueOf("dc=example,dc=com");
 
-    assertNotEquals(dn, "not a DN");
+    Assert.assertNotEquals(dn, "not a DN");
   }
 
 
@@ -1201,7 +1202,7 @@ public class TestDN extends TypesTestCase {
       assertEquals(h1, h2,
           "Hash codes for <" + first + "> and <" + second + "> should be the same.");
     } else {
-      assertNotEquals(h1, h2,
+      Assert.assertNotEquals(h1, h2,
           "Hash codes for <" + first + "> and <" + second + "> should be the same.");
     }
   }

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/TestRDN.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/TestRDN.java
@@ -23,12 +23,14 @@
  *
  *      Copyright 2006-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2014-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.types;
 
 import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.core.DirectoryServer.*;
 import static org.testng.Assert.*;
+import org.testng.Assert;
 
 import java.util.ArrayList;
 
@@ -576,7 +578,7 @@ public final class TestRDN extends TypesTestCase {
       assertEquals(rdn1, rdn2,
           "RDN equality for <" + first + "> and <" + second + ">");
     } else {
-      assertNotEquals(rdn1, rdn2,
+      Assert.assertNotEquals(rdn1, rdn2,
           "RDN equality for <" + first + "> and <" + second + ">");
     }
   }
@@ -608,7 +610,7 @@ public final class TestRDN extends TypesTestCase {
       assertEquals(h1, h2, "Hash codes for <" + first + "> and <" + second
           + "> should be the same.");
     } else {
-      assertNotEquals(h1, h2, "Hash codes for <" + first + "> and <" + second
+      Assert.assertNotEquals(h1, h2, "Hash codes for <" + first + "> and <" + second
           + "> should be the same.");
     }
   }
@@ -654,7 +656,7 @@ public final class TestRDN extends TypesTestCase {
   public void testEqualityNull() {
     RDN rdn = new RDN(AT_DC, AV_DC_ORG);
 
-    assertNotEquals(rdn, null);
+    Assert.assertNotEquals(rdn, null);
   }
 
 
@@ -666,7 +668,7 @@ public final class TestRDN extends TypesTestCase {
   public void testEqualityNonRDN() {
     RDN rdn = new RDN(AT_DC, AV_DC_ORG);
 
-    assertNotEquals(rdn, "this isn't an RDN");
+    Assert.assertNotEquals(rdn, "this isn't an RDN");
   }
 }
 


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-bom#2

Since last year, security alerts have been sent from GitHub about Maven dependencies.
After forking this BOM project, I noticed alerts fixed in OpenAM were also occurring.
It's annoying to fix the same alert across multiple projects.

## Solution
- Move dependencies defined in multiple projects to BOM
- Use BOM in each project
- Do not overwrite the dependency version defined in BOM in each project
- If multiple versions of the same library are used, unify them to the new version

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock--i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam

## Regression testing
There is no change in test results by test framework.
