### PR TITLE
Issue openam#33 Upgrade unit testing frameworks

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/DefaultIndexTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/DefaultIndexTest.java
@@ -22,12 +22,13 @@
  *
  *
  *      Copyright 2015 ForgeRock AS
+ *
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.backends.pluggable;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.opendj.ldap.ByteString.valueOfUtf8;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.opends.server.backends.pluggable.EntryIDSet.*;
 import static org.opends.server.backends.pluggable.State.IndexFlag.*;

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/Utils.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/Utils.java
@@ -22,6 +22,7 @@
  *
  *
  *      Portions Copyright 2013-2015 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.backends.pluggable;
 
@@ -36,7 +37,7 @@ final class Utils
 {
   public static void assertIdsEquals(Iterator<EntryID> actual, long... expected)
   {
-    assertThat(actual).containsAll(asList(expected));
+    assertThat(actual).toIterable().containsAll(asList(expected));
   }
 
   public static void assertIsEmpty(EntryIDSet actual)

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/ConfigurationHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/ConfigurationHandlerTestCase.java
@@ -22,10 +22,11 @@
  *
  *
  *      Copyright 2014-2015 ForgeRock AS.
+ *
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.core;
 
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.opends.server.ServerContextBuilder.*;
 import static org.testng.Assert.*;

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ModifyReplaySingleValuedAttributeTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ModifyReplaySingleValuedAttributeTest.java
@@ -21,11 +21,12 @@
  * CDDL HEADER END
  *
  *      Copyright 2015 ForgeRock AS
+ *
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.replication.plugin;
 
 import static org.forgerock.opendj.ldap.ModificationType.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.opends.server.util.CollectionUtils.*;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/ChangeNumberIndexerTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/ChangeNumberIndexerTest.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2013-2015 ForgeRock AS
  *      Portions Copyright 2014 ForgeRock AS
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.replication.server.changelog.file;
 
@@ -58,7 +59,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.opends.server.replication.server.changelog.api.DBCursor.KeyMatchingStrategy.*;
 import static org.opends.server.replication.server.changelog.api.DBCursor.PositionStrategy.*;

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/SmallMapTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/SmallMapTest.java
@@ -21,6 +21,8 @@
  * CDDL HEADER END
  *
  *      Copyright 2014-2015 ForgeRock AS
+ *
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.server.types;
 
@@ -159,15 +161,15 @@ public class SmallMapTest extends DirectoryServerTestCase
   public void testEntrySetIterator() throws Exception
   {
     SmallMap<Integer, String> map = new SmallMap<>();
-    assertThat(map.entrySet().iterator()).isEmpty();
+    assertThat(map.entrySet().iterator()).toIterable().isEmpty();
 
     map.put(1, "one");
-    assertThat(map.entrySet().iterator()).containsExactly(
+    assertThat(map.entrySet().iterator()).toIterable().containsExactly(
         entry(1, "one"));
 
     map.put(1, "one");
     map.put(2, "two");
-    assertThat(map.entrySet().iterator()).containsExactly(
+    assertThat(map.entrySet().iterator()).toIterable().containsExactly(
         entry(1, "one"), entry(2, "two"));
   }
 


### PR DESCRIPTION
## Analysis

openam-jp/openam#33

OpenAM uses the following unit testing frameworks.

* TestNG 6.8.5
* AssertJ 2.1.0
* Mockito 1.9.5
* EasyMock 3.2
* Powermock 1.5
* JUnit 4.10

Some frameworks do not support Java 11.
For example, Mockito supports Java 11 from version 2.20.1.


## Solution
Upgrade unit testing frameworks. Then, tests will pass in Java 8 environment.
- TestNG 6.14.3
- AssertJ 3.13.2
- Mockito 2.28.2
- EasyMoch 4.0.2
- PowerMock 2.0.2
- Junit 4.12


## Install/Update
This fix relies on aggregation of dependencies on the BOM.
The unit testing frameworks are updated by BOM.
To apply the fix, get the modules in the following order and build them.

- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam


## Regression testing
Test results from testframework have not changed.
