### PR TITLE
Issue openam#32 Support Java 11 (OpenJDK 11)

### DIFF
--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -23,6 +23,7 @@
   !
   !      Copyright 2015 ForgeRock AS.
   !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -147,6 +148,11 @@
             <classifier>zh_TW</classifier>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-ri</artifactId>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -194,6 +200,13 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
                 <version>1.6</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.1</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>prepare-dsml-library</id>

--- a/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLAddOperation.java
+++ b/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLAddOperation.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.dsml.protocol;
 
@@ -97,7 +98,7 @@ public class DSMLAddOperation
     for(DsmlAttr attr : addList)
     {
       ArrayList<ByteString> values = new ArrayList<>();
-      List<Object> vals = attr.getValue();
+      List vals = attr.getValue();
       for(Object val : vals)
       {
         values.add(ByteStringUtility.convertValue(val));

--- a/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLSearchOperation.java
+++ b/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLSearchOperation.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2009 Sun Microsystems, Inc.
  *      Portions Copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.opends.dsml.protocol;
 
@@ -290,7 +291,7 @@ public class DSMLSearchOperation
   private static LDAPFilter createSubstringFilter(SubstringFilter sf)
         throws LDAPException, IOException
   {
-    List<Object> anyo = sf.getAny();
+    List anyo = sf.getAny();
     ArrayList<ByteString> subAnyElements = new ArrayList<>(anyo.size());
 
     for (Object o : anyo)
@@ -581,11 +582,11 @@ public class DSMLSearchOperation
             DsmlAttr dsmlAttr = objFactory.createDsmlAttr();
 
             dsmlAttr.setName(nm);
-            List<Object> dsmlAttrVal = dsmlAttr.getValue();
+            List dsmlAttrVal = dsmlAttr.getValue();
             List<ByteString> vals = attr.getValues();
             for (ByteString val : vals)
             {
-              dsmlAttrVal.add(ByteStringUtility.convertByteString(val));
+              dsmlAttrVal.add((String)ByteStringUtility.convertByteString(val));
             }
             attrList.add(dsmlAttr);
           }

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -228,6 +228,11 @@
       <artifactId>forgerock-persistit-core</artifactId>
       <version>4.3.2-SNAPSHOT</version>
     </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Analysis
openam-jp/openam#32

OpenAM now supports Java8.

While Java 8 is supported by various vendors, but public updates of Oracle Java will close soon.
Also, since release 9, the release model has changed.

OpenAM needs to support Java 11, the latest long-term support Java version.

## Solution
Support Java 11 (OpenJDK 11) as development environment and execution environment.

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam
