### PR TITLE
Issue openam#219 Upgrade Jackson library to 2.10.x

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -195,7 +195,7 @@
 
     <dependency>
       <groupId>com.sun.mail</groupId>
-      <artifactId>javax.mail</artifactId>
+      <artifactId>jakarta.mail</artifactId>
     </dependency>
 
     <!-- We need to override testNG version to make test works (see OPENDJ-2389) -->

--- a/opendj-server-legacy/src/main/assembly/opendj-archive-component.xml
+++ b/opendj-server-legacy/src/main/assembly/opendj-archive-component.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyright 2020 Open Source Solution Technology Corporation
   !
 -->
 <!-- OpenDJ final archive content descriptor -->
@@ -34,7 +35,7 @@
       <scope>runtime</scope>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <excludes>
-        <exclude>javax.activation:activation</exclude>
+        <exclude>com.sun.activation:jakarta.activation</exclude>
         <exclude>jp.openam.opendj:opendj-server-legacy</exclude>
       </excludes>
     </dependencySet>


### PR DESCRIPTION
## Analysis

openam-jp/openam#219

Newer version of Jackson depend on some Jakarta EE library. And these conflict with the libraries included in this project.

* jakarta.activation-api-1.2.1.jar vs activation-1.1.jar

But javax.mail depend on Java EE activation. We need to change javax.mail too.

## Solution

* activation-> jakarta.activation
* javax.mail -> jakarta.mail

## Testing

Unit tests works fine.