### PR TITLE
Issue openam#239 TLSv1.2 or higher support

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/admin/ads/util/TrustedSocketFactory.java
+++ b/opendj-server-legacy/src/main/java/org/opends/admin/ads/util/TrustedSocketFactory.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2008 Sun Microsystems, Inc.
  *      Portions Copyright 2015 ForgeRock AS.
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 
 package org.opends.admin.ads.util;
@@ -256,7 +257,7 @@ public class TrustedSocketFactory extends SSLSocketFactory
   private SSLSocketFactory getInnerFactory() throws IOException {
     if (innerFactory == null)
     {
-      String algorithm = "TLSv1";
+      String algorithm = "TLS";
       SSLKeyException xx;
       KeyManager[] km = null;
       TrustManager[] tm = null;

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/jmx/RmiConnector.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/jmx/RmiConnector.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2006-2009 Sun Microsystems, Inc.
  *      Portions Copyright 2013-2015 ForgeRock AS.
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 package org.opends.server.protocols.jmx;
 
@@ -295,7 +296,7 @@ public class RmiConnector
               : SelectableCertificateKeyManager.wrap(provider.getKeyManagers(), nicknames);
         }
 
-        SSLContext ctx = SSLContext.getInstance("TLSv1");
+        SSLContext ctx = SSLContext.getInstance("TLS");
         ctx.init(
             keyManagers,
             null,

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/ManageTasks.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/ManageTasks.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2008-2009 Sun Microsystems, Inc.
  *      Portions Copyright 2012-2015 ForgeRock AS.
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 package org.opends.server.tools;
 
@@ -313,8 +314,8 @@ public class ManageTasks extends ConsoleApplication {
            printSummaryTable();
            return 0;
         }
-      } catch (LDAPConnectionException lce) {
-        println(INFO_TASKINFO_LDAP_EXCEPTION.get(lce.getMessageObject()));
+      } catch (LDAPConnectionException | SSLConnectionException e) {
+        println(INFO_TASKINFO_LDAP_EXCEPTION.get(e.getMessageObject()));
         return 1;
       } catch (Exception e) {
         println(LocalizableMessage.raw(StaticUtils.getExceptionMessage(e)));

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/status/StatusCli.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/status/StatusCli.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2007-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 package org.opends.server.tools.status;
 
@@ -96,6 +97,7 @@ import org.opends.server.util.cli.LDAPConnectionConsoleInteraction;
 import com.forgerock.opendj.cli.ArgumentException;
 import com.forgerock.opendj.cli.CliConstants;
 import com.forgerock.opendj.cli.ClientException;
+import com.forgerock.opendj.cli.ConnectionFactoryProvider;
 import com.forgerock.opendj.cli.ConsoleApplication;
 import com.forgerock.opendj.cli.ReturnCode;
 import com.forgerock.opendj.cli.TableBuilder;
@@ -1186,6 +1188,7 @@ public class StatusCli extends ConsoleApplication
         sslBuilder.setKeyManager(keyManager);
         options.set(SSL_USE_STARTTLS, ci.useStartTLS());
         options.set(SSL_CONTEXT, sslBuilder.getSSLContext());
+        options.set(SSL_ENABLED_PROTOCOLS, ConnectionFactoryProvider.getDefaultProtocols());
 
         factory = new LDAPConnectionFactory(hostName, portNumber, options);
         connection = factory.getConnection();

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/args/LDAPConnectionArgumentParser.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/args/LDAPConnectionArgumentParser.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2008-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 package org.opends.server.util.args;
 
@@ -296,13 +297,15 @@ public class LDAPConnectionArgumentParser extends ArgumentParser
    * @param err
    *          stream to write error messages
    * @return LDAPConnection created by this class from parsed arguments
+   * @throws SSLConnectionException
+   *           if there was a problem connecting with SSL to the server
    * @throws LDAPConnectionException
-   *           if there was a problem connecting to the server
+   *           if there was any other problem connecting to the server
    * @throws ArgumentException
    *           if there was a problem indicated by the input arguments
    */
   public LDAPConnection connect(LDAPConnectionConsoleInteraction ui, PrintStream out, PrintStream err)
-      throws LDAPConnectionException, ArgumentException
+      throws LDAPConnectionException, SSLConnectionException, ArgumentException
   {
     try
     {
@@ -316,7 +319,7 @@ public class LDAPConnectionArgumentParser extends ArgumentParser
     {
       err.println(isSSLException(e) ?
           ERR_TASKINFO_LDAP_EXCEPTION_SSL.get(ui.getHostName(), ui.getPortNumber()) : e.getMessageObject());
-      return null;
+      throw e;
     }
   }
 


### PR DESCRIPTION
## Analysis

openam-jp/openam#239

The OpenDJ SDK, OpenDJ, and OpenAM specify TLSv1.0 as the SSL context protocol.
The current standard version of TLS is TLSv1.2, which causes the following issues:
 - In RHEL 8 / CentOS 8, TLSv1.0 is disabled by the system-wide encryption policy. Therefore, some functions and test code do not work properly.
 - The OpenJDK, scheduled for release in 2021/04, will change the security settings of Java to disable TLSv1.0 and TLSv1.1.


## Solution

Make the OpenDJ SDK, OpenDJ, and OpenAM projects compatible with TLSv1.2 or higher.
Some parts of these projects are hard-coded to use TLSv1.0.
We will revise these parts to be written in an appropriate way to follow TLSv1.2 or higher.
