### PR TITLE
Issue openam#291 OpenDJ version checks are inconsistent

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/util/BuildVersion.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/BuildVersion.java
@@ -109,7 +109,7 @@ public final class BuildVersion implements Comparable<BuildVersion>
    */
   public static void checkVersionMismatch() throws InitializationException
   {
-    if (!BuildVersion.binaryVersion().toString().equals(BuildVersion.instanceVersion().toString()))
+    if (!BuildVersion.binaryVersion().equals(BuildVersion.instanceVersion()))
     {
       throw new InitializationException(
           ERR_BUILDVERSION_MISMATCH.get(BuildVersion.binaryVersion(), BuildVersion.instanceVersion()));


### PR DESCRIPTION
## Analysis

See openam-jp/openam#291

## Solution

Ignore the buildRevision in OpenDJ version check

## Testing

I performed the following tests with openam-jp/openam#292.

* Upgrade with OpenAM including new `buildRevision` OpenDJ
    * OpenDJ upgrade will be skipped
* Upgrade form 14.0.0 to 15.0.0-SNAPSHOT
    * OpenDJ upgrade succeeds