### PR TITLE
Issue #9 Several build errors (Blocked mirror) occur in Maven 3.8.1 environment

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -22,7 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
-  !      Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+  !      Portions Copyrighted 2019-2026 OSSTech Corporation
   !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   !
 -->
@@ -46,7 +46,7 @@
     <repository>
       <id>oracle-repository</id>
       <name>Oracle Maven Repository</name>
-      <url>http://download.oracle.com/maven</url>
+      <url>https://download.oracle.com/maven</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
## Analysis

See #9

## Solution

Change the URL of the Oracle Maven Repository to HTTPS
