### PR TITLE
Issue openam#313 Initial configuration fails on RHEL 9

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/util/Platform.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/Platform.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2013-2015 ForgeRock AS.
+ *      Portions Copyright 2026 OSSTech Corporation
  */
 
 package org.opends.server.util;
@@ -100,11 +101,11 @@ public final class Platform
   /** Key size, key algorithm and signature algorithms used. */
   public static enum KeyType
   {
-    /** RSA key algorithm with 2048 bits size and SHA1withRSA signing algorithm. */
-    RSA("rsa", 2048, "SHA1WithRSA"),
+    /** RSA key algorithm with 2048 bits size and SHA256withRSA signing algorithm. */
+    RSA("rsa", 2048, "SHA256WithRSA"),
 
-    /** Elliptic Curve key algorithm with 233 bits size and SHA1withECDSA signing algorithm. */
-    EC("ec", 256, "SHA1withECDSA");
+    /** Elliptic Curve key algorithm with 256 bits size and SHA256withECDSA signing algorithm. */
+    EC("ec", 256, "SHA256withECDSA");
 
     /** Default key type used when none can be determined. */
     public final static KeyType DEFAULT = RSA;


### PR DESCRIPTION
## Analysis

See openam-jp/openam#313

## Solution

Change the signature algorithm of the self-signed certificate to SHA-256.

## Testing

The following tests were performed in combination with OpenAM.

* Initial configuration of OpenAM succeeds on RHEL 9
* The signature algorithm of the certificate for the admin port becomes sha256WithRSAEncryption
* In an upgraded OpenAM environment, the signature algorithm of the certificate for the admin port remains sha1WithRSAEncryption