### PR TITLE
Issue #16 Duplicate records are written to changelogDb

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/Log.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/Log.java
@@ -46,7 +46,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.util.Pair;
 import org.forgerock.util.Reject;
@@ -154,13 +153,6 @@ final class Log<K extends Comparable<K>, V> implements Closeable
    * The read-only log files are associated with the highest key they contain.
    */
   private final TreeMap<K, LogFile<K, V>> logFiles = new TreeMap<>();
-
-  /**
-   * The last key appended to the log. In order to keep the ordering of the keys
-   * in the log, any attempt to append a record with a key lower or equal to
-   * this key is rejected (no error but an event is logged).
-   */
-  private K lastAppendedKey;
 
   /**
    * The list of non-empty cursors opened on this log. Opened cursors may have
@@ -419,13 +411,11 @@ final class Log<K extends Comparable<K>, V> implements Closeable
    * <p>
    * The record must have a key strictly higher than the key
    * of the last record added. If it is not the case, the record is not
-   * appended and the method returns immediately.
+   * appended.
    * <p>
    * In order to ensure that record is written out of buffers and persisted
    * to file system, it is necessary to explicitly call the
    * {@code syncToFileSystem()} method.
-   * <p>
-   * This method is not thread-safe.
    *
    * @param record
    *          The record to add.
@@ -434,15 +424,6 @@ final class Log<K extends Comparable<K>, V> implements Closeable
    */
   public void append(final Record<K, V> record) throws ChangelogException
   {
-    // This check is ok outside of any locking because only the append thread updates lastAppendedKey.
-    if (recordIsBreakingKeyOrdering(record))
-    {
-      logger.info(LocalizableMessage.raw(
-              "Rejecting append to log '%s' for record: [%s], last key appended: [%s]", logPath.getPath(), record,
-              lastAppendedKey != null ? lastAppendedKey : "null"));
-      return;
-    }
-
     // Fast-path - assume that no rotation is needed and use shared lock.
     sharedLock.lock();
     try
@@ -455,7 +436,6 @@ final class Log<K extends Comparable<K>, V> implements Closeable
       if (!mustRotate(headLogFile))
       {
         headLogFile.append(record);
-        lastAppendedKey = record.getKey();
         return;
       }
     }
@@ -473,6 +453,11 @@ final class Log<K extends Comparable<K>, V> implements Closeable
         return;
       }
       LogFile<K, V> headLogFile = getHeadLogFile();
+      if (headLogFile.appendWouldBreakKeyOrdering(record))
+      {
+        // abort rotation
+        return;
+      }
       if (mustRotate(headLogFile))
       {
         logger.trace(INFO_CHANGELOG_LOG_FILE_ROTATION.get(logPath.getPath(), headLogFile.getSizeInBytes()));
@@ -481,7 +466,6 @@ final class Log<K extends Comparable<K>, V> implements Closeable
         headLogFile = getHeadLogFile();
       }
       headLogFile.append(record);
-      lastAppendedKey = record.getKey();
     }
     finally
     {
@@ -491,7 +475,7 @@ final class Log<K extends Comparable<K>, V> implements Closeable
 
   private boolean mustRotate(LogFile<K, V> headLogFile)
   {
-    if (lastAppendedKey == null)
+    if (headLogFile.getNewestRecord() == null)
     {
       // never rotate an empty file
       return false;
@@ -515,12 +499,6 @@ final class Log<K extends Comparable<K>, V> implements Closeable
       return shouldRotate;
     }
     return false;
-  }
-
-  /** Indicates if the provided record has a key that would break the key ordering in the log. */
-  private boolean recordIsBreakingKeyOrdering(final Record<K, V> record)
-  {
-    return lastAppendedKey != null && record.getKey().compareTo(lastAppendedKey) <= 0;
   }
 
   /**
@@ -1123,8 +1101,6 @@ final class Log<K extends Comparable<K>, V> implements Closeable
   private void openHeadLogFile() throws ChangelogException
   {
     final LogFile<K, V> head = LogFile.newAppendableLogFile(new File(logPath,  HEAD_LOG_FILE_NAME), recordParser);
-    final Record<K,V> newestRecord = head.getNewestRecord();
-    lastAppendedKey = newestRecord != null ? newestRecord.getKey() : null;
     logFiles.put(recordParser.getMaxKey(), head);
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/LogFile.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/LogFile.java
@@ -113,23 +113,24 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
     Reject.ifNull(logFilePath, parser);
     this.logfile = logFilePath;
     this.isWriteEnabled = isWriteEnabled;
-
+    final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+    exclusiveLock = rwLock.writeLock();
+    sharedLock = rwLock.readLock();
     createLogFileIfNotExists();
+
+    readerPool = new LogReaderPool<>(logfile, parser);
     if (isWriteEnabled)
     {
       ensureLogFileIsValid(parser);
       writer = BlockLogWriter.newWriter(new LogWriter(logfile), parser);
+      initializeNewestRecord();
     }
     else
     {
+      // Newest record is never requested for read-only log files.
+      // It will never be because it is available in the file name.
       writer = null;
     }
-    readerPool = new LogReaderPool<>(logfile, parser);
-
-    final ReadWriteLock rwLock = new ReentrantReadWriteLock();
-    exclusiveLock = rwLock.writeLock();
-    sharedLock = rwLock.readLock();
-    initializeNewestRecord();
   }
 
   /**
@@ -418,7 +419,8 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
     }
     catch (IOException ioe)
     {
-      throw new ChangelogException(ERR_CHANGELOG_CANNOT_READ_NEWEST_RECORD.get(logfile.getAbsolutePath()), ioe);
+      throw new ChangelogException(ERR_CHANGELOG_CANNOT_READ_NEWEST_RECORD.get(logfile.getAbsolutePath() + "- " +
+          StaticUtils.stackTraceToSingleLineString(ioe) + "-" + Thread.currentThread()), ioe);
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/LogFile.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/LogFile.java
@@ -21,7 +21,7 @@
  * CDDL HEADER END
  *
  *
- *      Copyright 2014-2015 ForgeRock AS.
+ * Copyright 2014-2016 ForgeRock AS.
  */
 package org.opends.server.replication.server.changelog.file;
 
@@ -87,6 +87,11 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
   /** Lock used to ensure that log file is in a consistent state when reading it. */
   private final Lock sharedLock;
 
+  /**
+   * The newest (last) record appended to this log file. In order to keep the ordering of the keys
+   * in the log file, any attempt to append a record with a key lower or equal to this key is
+   * rejected (no error but an event is logged).
+   */
   private Record<K, V> newestRecord;
 
   /**
@@ -124,6 +129,7 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
     final ReadWriteLock rwLock = new ReentrantReadWriteLock();
     exclusiveLock = rwLock.writeLock();
     sharedLock = rwLock.readLock();
+    initializeNewestRecord();
   }
 
   /**
@@ -237,9 +243,11 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
   /**
    * Add the provided record at the end of this log.
    * <p>
-   * In order to ensure that record is written out of buffers and persisted
-   * to file system, it is necessary to explicitely call the
-   * {@code syncToFileSystem()} method.
+   * The record must have a key strictly higher than the key of the last record added.
+   * If it is not the case, the record is not appended.
+   * <p>
+   * In order to ensure that record is written out of buffers and persisted to file system, it is
+   * necessary to explicitly call the {@link #syncToFileSystem()} method.
    *
    * @param record
    *          The record to add.
@@ -252,6 +260,10 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
     exclusiveLock.lock();
     try
     {
+      if (appendWouldBreakKeyOrdering(record))
+      {
+        return;
+      }
       writer.write(record);
       newestRecord = record;
     }
@@ -259,6 +271,18 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
     {
       exclusiveLock.unlock();
     }
+  }
+
+  /** Indicates if the provided record has a key that would break the key ordering if appended in this file log. */
+  boolean appendWouldBreakKeyOrdering(final Record<K, V> record)
+  {
+    boolean wouldBreakOrder = newestRecord != null && record.getKey().compareTo(newestRecord.getKey()) <= 0;
+    if (wouldBreakOrder)
+    {
+      logger.debug(
+          INFO_CHANGELOG_FILTER_OUT_RECORD_BREAKING_ORDER.get(logfile.getPath(), record, newestRecord.getKey()));
+    }
+    return wouldBreakOrder;
   }
 
   /**
@@ -373,28 +397,29 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
    * @throws ChangelogException
    *           If an error occurs while retrieving the record.
    */
-  Record<K, V> getNewestRecord() throws ChangelogException
+  Record<K, V> getNewestRecord()
   {
-    if (newestRecord == null)
+    return newestRecord;
+  }
+
+  private void initializeNewestRecord() throws ChangelogException
+  {
+    try (BlockLogReader<K, V> reader = getReader())
     {
-      try (BlockLogReader<K, V> reader = getReader())
+      sharedLock.lock();
+      try
       {
-        sharedLock.lock();
-        try
-        {
-          newestRecord = reader.getNewestRecord();
-        }
-        finally
-        {
-          sharedLock.unlock();
-        }
+        newestRecord = reader.getNewestRecord();
       }
-      catch (IOException ioe)
+      finally
       {
-        throw new ChangelogException(ERR_CHANGELOG_CANNOT_READ_NEWEST_RECORD.get(logfile.getAbsolutePath()), ioe);
+        sharedLock.unlock();
       }
     }
-    return newestRecord;
+    catch (IOException ioe)
+    {
+      throw new ChangelogException(ERR_CHANGELOG_CANNOT_READ_NEWEST_RECORD.get(logfile.getAbsolutePath()), ioe);
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
@@ -635,3 +635,5 @@ ERR_CHANGELOG_RESET_CHANGE_NUMBER_CHANGE_NOT_PRESENT_293=The change number index
 ERR_CHANGELOG_RESET_CHANGE_NUMBER_CSN_TOO_OLD_294=The change number could not be reset to %d because the associated \
   change with CSN '%s' has already been purged from the change log. Try resetting to a more recent change
 ERR_REPLICATION_CHANGE_NUMBER_DISABLED_295=Change number indexing is disabled for replication domain '%s'
+INFO_CHANGELOG_FILTER_OUT_RECORD_BREAKING_ORDER_296=Filtering out from log file '%s' the record '%s'\
+ because it would break ordering. Last key appended is '%s'.

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/LogFileTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/LogFileTest.java
@@ -21,7 +21,7 @@
  * CDDL HEADER END
  *
  *
- *      Copyright 2014-2015 ForgeRock AS.
+ * Copyright 2014-2016 ForgeRock AS.
  */
 package org.opends.server.replication.server.changelog.file;
 
@@ -277,9 +277,9 @@ public class LogFileTest extends DirectoryServerTestCase
   {
     try (LogFile<String, String> writeLog = getLogFile(RECORD_PARSER))
     {
-      for (int i = 1; i <= 100; i++)
+      for (int i = 1; i <= 90; i++)
       {
-        Record<String, String> record = Record.from("newkey" + i, "newvalue" + i);
+        Record<String, String> record = Record.from(String.format("newkey%02d", i), "newvalue" + i);
         writeLog.append(record);
         assertThat(writeLog.getNewestRecord()).as("write changelog " + i).isEqualTo(record);
         assertThat(writeLog.getOldestRecord()).as("write changelog " + i).isEqualTo(Record.from("key01", "value1"));


### PR DESCRIPTION
## Solution

Apply the fixes from e84de8ea992525eb6ac672ddc764e3a4825e36d9 and fa6a436d8ae0dd3686f586953a7cacc38a8674c7.

## Testing

Record duplication could not be reproduced during debugging.